### PR TITLE
add the ability to limit supported TLDs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,8 @@ pub struct ConfigFile {
     pub sqlite_path: String,
     /// Where the JSON zone file is
     pub zone_file: Option<String>,
+    /// List of "valid" TLDs - if this is empty let anything be created
+    pub allowed_tlds: Vec<String>,
     /// IP Allow lists
     #[serde(flatten)]
     pub ip_allow_lists: IPAllowList,
@@ -271,6 +273,7 @@ impl Default for ConfigFile {
             log_level: "INFO".to_string(),
             tcp_client_timeout: 5,
             enable_hinfo: false,
+            allowed_tlds: vec![],
             ip_allow_lists: IPAllowList {
                 // axfr: vec![],
                 shutdown: vec![],
@@ -375,6 +378,9 @@ impl From<Config> for ConfigFile {
             sqlite_path: config
                 .get("sqlite_path")
                 .unwrap_or(Self::default().sqlite_path),
+            allowed_tlds: config
+                .get("allowed_tlds")
+                .unwrap_or(Self::default().allowed_tlds),
             zone_file: config.get("zone_file").unwrap_or(Self::default().zone_file),
             enable_api: config
                 .get("enable_api")

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -2,7 +2,7 @@ use std::str::from_utf8;
 
 use url::Url;
 
-use crate::utils::{find_tail_match, loc_size_to_u8, name_as_bytes};
+use crate::utils::{check_valid_tld, find_tail_match, loc_size_to_u8, name_as_bytes};
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -99,4 +99,28 @@ pub fn test_name_bytes_with_tail_compression() {
     let result = name_as_bytes(test_input, Some(12), Some(&example_com));
 
     assert_eq!(result, expected_result);
+}
+
+#[test]
+fn test_test_valid_tld() {
+    // empty list
+    let valid_tlds = vec![];
+    let zone_name = "hello.example.goat";
+    assert_eq!(check_valid_tld(&zone_name, &valid_tlds), true);
+
+    let valid_tlds = vec!["goat".to_string()];
+    let zone_name = "hello.example.goat";
+    assert_eq!(check_valid_tld(&zone_name, &valid_tlds), true);
+
+    let valid_tlds = vec!["cheese".to_string()];
+    let zone_name = "hello.example.goat";
+    assert_eq!(check_valid_tld(&zone_name, &valid_tlds), false);
+
+    let valid_tlds = vec!["goat".to_string()];
+    let zone_name = "hello.example.happygoat";
+    assert_eq!(check_valid_tld(&zone_name, &valid_tlds), false);
+
+    let valid_tlds = vec!["goat".to_string()];
+    let zone_name = "hello.example.goat.cheese";
+    assert_eq!(check_valid_tld(&zone_name, &valid_tlds), false);
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -311,3 +311,31 @@ pub fn start_channels() -> (
     (datastore_sender, datastore_receiver) = mpsc::channel(crate::MAX_IN_FLIGHT);
     (agent_tx, datastore_sender, datastore_receiver)
 }
+
+/// Compares the TLD to the list of valid TLDs - usually from `allowed_tlds` in [crate::config::ConfigFile]
+///```
+/// use goatns::utils::check_valid_tld;
+///
+/// let valid_tlds = vec![];
+/// let zone_name = "hello.example.goat";
+/// assert_eq!(check_valid_tld(&zone_name, &valid_tlds), true);
+///
+/// let valid_tlds = vec!["goat".to_string()];
+/// let zone_name = "hello.example.goat";
+/// assert_eq!(check_valid_tld(&zone_name, &valid_tlds), true);
+///
+/// let valid_tlds = vec!["cheese".to_string()];
+/// let zone_name = "hello.example.goat";
+/// assert_eq!(check_valid_tld(&zone_name, &valid_tlds), false);
+/// ```
+pub fn check_valid_tld(zone_name: &str, allowed_tlds: &Vec<String>) -> bool {
+    if allowed_tlds.is_empty() {
+        return true;
+    }
+    for tld in allowed_tlds.iter() {
+        if zone_name.ends_with(&format!(".{tld}")) {
+            return true;
+        }
+    }
+    false
+}

--- a/src/web/api/filezone.rs
+++ b/src/web/api/filezone.rs
@@ -4,6 +4,7 @@ use crate::db::DBEntity;
 use crate::db::User;
 use crate::db::ZoneOwnership;
 use crate::error_result_json;
+use crate::utils::check_valid_tld;
 use crate::zones::FileZone;
 use axum::extract::Path;
 use axum::Json;
@@ -40,6 +41,10 @@ impl APIEntity for FileZone {
                 return error_result_json!(res.as_str(), StatusCode::BAD_REQUEST);
             }
         };
+
+        if !check_valid_tld(&zone.name, &state.read().await.config.allowed_tlds) {
+            return error_result_json!("Invalid TLD for this system", StatusCode::BAD_REQUEST);
+        }
 
         // check to see if the zone exists
         let mut txn = state.connpool().await.begin().await.unwrap();
@@ -156,6 +161,10 @@ impl APIEntity for FileZone {
             }
         };
         println!("deser'd zone: {zone:?}");
+
+        if !check_valid_tld(&zone.name, &state.read().await.config.allowed_tlds) {
+            return error_result_json!("Invalid TLD for this system", StatusCode::BAD_REQUEST);
+        }
 
         // get a db transaction
         let connpool = state.connpool().await.clone();

--- a/src/web/api/filezonerecord.rs
+++ b/src/web/api/filezonerecord.rs
@@ -59,7 +59,7 @@ impl APIEntity for FileZoneRecord {
             }
         }
     }
-    /// HTTP Put https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PUT
+    /// HTTP Put <https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PUT>
     async fn api_update(
         State(state): State<GoatState>,
         session: ReadableSession,
@@ -118,7 +118,7 @@ impl APIEntity for FileZoneRecord {
     }
 
     /// Delete an object
-    /// https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE
+    /// <https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE>
     async fn api_delete(
         State(state): State<GoatState>,
         session: ReadableSession,

--- a/src/web/api/mod.rs
+++ b/src/web/api/mod.rs
@@ -60,7 +60,7 @@ trait APIEntity {
         session: ReadableSession,
         Json(payload): Json<serde_json::Value>,
     ) -> Result<Json<String>, (StatusCode, Json<ErrorResult>)>;
-    /// HTTP Put https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PUT
+    /// HTTP Put <https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PUT>
     async fn api_update(
         State(state): State<GoatState>,
         session: ReadableSession,
@@ -73,7 +73,7 @@ trait APIEntity {
     ) -> Result<Json<Box<Self>>, (StatusCode, Json<ErrorResult>)>;
 
     /// Delete an object
-    /// https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE
+    /// <https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE>
     async fn api_delete(
         State(state): State<GoatState>,
         session: ReadableSession,


### PR DESCRIPTION
Adds a config option `allowed_tlds` which if it has an entry, blocks adding TLDs.

Fixes #35