### PR TITLE
Changing the base container for building to match the target container for packaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest AS builder
+FROM debian:latest AS builder
 
 ARG GITHUB_SHA="${GITHUB_SHA}"
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help:
 container:	## Build the docker image locally
 container:
 	$(eval GITHUB_SHA:=$(shell  git rev-parse HEAD))
-	@$(CONTAINER_TOOL) build $(CONTAINER_TOOL_ARGS) \
+	@$(CONTAINER_TOOL) buildx build $(CONTAINER_TOOL_ARGS) \
 	--build-arg GITHUB_SHA="${GITHUB_SHA}" \
 	-t $(IMAGE_BASE)/server:$(IMAGE_VERSION) $(CONTAINER_BUILD_ARGS) .
 
@@ -27,7 +27,7 @@ run_container: ## Run the container
 run_container:
 	@$(CONTAINER_TOOL) run $(CONTAINER_TOOL_ARGS) \
 	--rm -it \
-	--mount  "type=bind,src=${HOME}/.config/goatns.json,target=/goatns.json" \
+	--mount "type=bind,src=${HOME}/.config/goatns.json,target=/goatns.json" \
 	$(IMAGE_BASE)/server:$(IMAGE_VERSION)
 
 build: ## Build release binaries


### PR DESCRIPTION
Previously the container was being built on a Ubuntu base and now it has a different version of GLIBC underneath it, moved to Debian and it's matching the distroless base now.