### PR TITLE
test and API docs fixing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,11 +444,11 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "pin-project-lite",
  "tower",
  "tracing",
- "tracing-opentelemetry 0.31.0",
+ "tracing-opentelemetry",
  "tracing-opentelemetry-instrumentation-sdk",
 ]
 
@@ -1892,7 +1892,7 @@ dependencies = [
  "num-traits",
  "oauth2",
  "openidconnect",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
@@ -1926,7 +1926,7 @@ dependencies = [
  "tower-sessions",
  "tower-sessions-sqlx-store",
  "tracing",
- "tracing-opentelemetry 0.32.1",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
  "utoipa",
@@ -2446,13 +2446,13 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b02953096a9025ec8c1aa83c2709e87a3e0fd247640becad4d68ac16db884e44"
 dependencies = [
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "thiserror 2.0.17",
  "tracing",
- "tracing-opentelemetry 0.31.0",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 
@@ -2957,19 +2957,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 2.0.17",
-]
-
-[[package]]
 name = "opentelemetry-http"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2978,7 +2965,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "http",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "reqwest",
 ]
 
@@ -2989,7 +2976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
 dependencies = [
  "http",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
@@ -3007,7 +2994,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
 dependencies = [
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "opentelemetry_sdk",
  "prost 0.13.5",
  "tonic 0.13.1",
@@ -3028,7 +3015,7 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "percent-encoding",
  "rand 0.9.2",
  "serde_json",
@@ -5564,24 +5551,8 @@ checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "opentelemetry_sdk",
- "smallvec",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber",
- "web-time",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
-dependencies = [
- "js-sys",
- "opentelemetry 0.31.0",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -5597,9 +5568,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13836788f587ab71400ef44b07196430782b5e483e189933c38dddb81381574"
 dependencies = [
  "http",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "tracing",
- "tracing-opentelemetry 0.31.0",
+ "tracing-opentelemetry",
 ]
 
 [[package]]

--- a/benches/baselines.rs
+++ b/benches/baselines.rs
@@ -1,6 +1,6 @@
 use std::hint::black_box;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 fn fibonacci(n: u64) -> u64 {
     match n {

--- a/src/db/entities/zones.rs
+++ b/src/db/entities/zones.rs
@@ -4,7 +4,7 @@ use crate::{
     enums::RecordClass, resourcerecord::InternalResourceRecord, web::api::zones::ZoneForm,
 };
 
-#[derive(Clone, Debug, DeriveEntityModel, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, DeriveEntityModel, Eq, Deserialize, Serialize, ToSchema)]
 #[sea_orm(table_name = "zones")]
 #[allow(dead_code)] // because clippy and auto-generated code
 pub struct Model {

--- a/src/db/migrations/m_20260203_zones_ids_uuid.rs
+++ b/src/db/migrations/m_20260203_zones_ids_uuid.rs
@@ -142,7 +142,7 @@ impl MigrationTrait for Migration {
                     )
                     .await?;
                 db.execute_unprepared(
-                "INSERT INTO records_new (id, zoneid, name, ttl, rrtype, rclass, rdata)
+                    "INSERT INTO records_new (id, zoneid, name, ttl, rrtype, rclass, rdata)
                     SELECT record_id_map.new_id, zone_id_map.new_id, records.name, records.ttl,
                            records.rrtype, records.rclass, records.rdata
                     FROM records

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -43,7 +43,7 @@ pub async fn get_conn(
 }
 
 #[cfg(test)]
-/// Get a sqlite pool with a memory-only database
+/// Get a sqlite db with a memory-only storage
 pub async fn test_get_sqlite_memory() -> DatabaseConnection {
     crate::init_crypto();
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -23,8 +23,10 @@ async fn get_conn_inner(
         .acquire_timeout(Duration::from_secs(10))
         .idle_timeout(Duration::from_secs(10))
         .max_lifetime(Duration::from_secs(180))
-        .sqlx_logging(log_sql_statements)
-        .max_connections(1);
+        .sqlx_logging(log_sql_statements);
+    #[cfg(test)]
+    opt.max_connections(1);
+
     Database::connect(opt).await.map_err(GoatNsError::from)
 }
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -19,11 +19,12 @@ async fn get_conn_inner(
     debug!("Opening Database: {db_url}");
     let mut opt = ConnectOptions::new(db_url);
 
-    opt.connect_timeout(Duration::from_secs(3))
-        .acquire_timeout(Duration::from_secs(5))
-        .idle_timeout(Duration::from_secs(1))
-        .max_lifetime(Duration::from_secs(30))
-        .sqlx_logging(log_sql_statements);
+    opt.connect_timeout(Duration::from_secs(10))
+        .acquire_timeout(Duration::from_secs(10))
+        .idle_timeout(Duration::from_secs(10))
+        .max_lifetime(Duration::from_secs(180))
+        .sqlx_logging(log_sql_statements)
+        .max_connections(1);
     Database::connect(opt).await.map_err(GoatNsError::from)
 }
 

--- a/src/db/test.rs
+++ b/src/db/test.rs
@@ -9,7 +9,7 @@ use sea_orm::{
 
 #[tokio::test]
 async fn create_user() -> Result<(), GoatNsError> {
-    let pool = test_get_sqlite_memory().await;
+    let dbconn = test_get_sqlite_memory().await;
 
     let user = entities::users::ActiveModel {
         id: NotSet,
@@ -22,14 +22,14 @@ async fn create_user() -> Result<(), GoatNsError> {
     };
 
     println!("Creating user the first time");
-    let model = user.insert(&pool).await?;
+    let model = user.insert(&dbconn).await?;
 
     let mut user = model.into_active_model();
 
     user.disabled = Set(false);
 
     println!("Updating user to disable second time");
-    user.update(&pool)
+    user.update(&dbconn)
         .await
         .expect("Failed to update user after creation");
 
@@ -69,16 +69,16 @@ pub async fn test_create_example_com_records(
 
 #[tokio::test]
 async fn test_get_zone_records() -> Result<(), GoatNsError> {
-    let pool = test_get_sqlite_memory().await;
-    let zone = test_create_example_com_zone(&pool)
+    let dbconn = test_get_sqlite_memory().await;
+    let zone = test_create_example_com_zone(&dbconn)
         .await
         .expect("Failed to create example.com zone");
 
-    test_create_example_com_records(&pool, zone.id, 1000).await?;
+    test_create_example_com_records(&dbconn, zone.id, 1000).await?;
 
     let records = zone
         .find_related(entities::records::Entity)
-        .all(&pool)
+        .all(&dbconn)
         .await
         .expect("Failed to get records");
 
@@ -102,11 +102,11 @@ pub fn test_example_com_zone() -> entities::zones::ActiveModel {
 /// A whole lotta tests
 #[tokio::test]
 async fn test_db_create_records() -> Result<(), GoatNsError> {
-    let pool = test_get_sqlite_memory().await;
+    let dbconn = test_get_sqlite_memory().await;
 
     println!("Creating Zone");
     let zone = test_example_com_zone()
-        .insert(&pool)
+        .insert(&dbconn)
         .await
         .expect("Failed to save the zone!");
 
@@ -122,12 +122,12 @@ async fn test_db_create_records() -> Result<(), GoatNsError> {
     };
     println!("rec to create: {rec_to_create:?}");
     rec_to_create
-        .insert(&pool)
+        .insert(&dbconn)
         .await
         .expect("Failed to create record");
 
     let res = entities::records_merged::Entity::get_records(
-        &pool,
+        &dbconn,
         "foo",
         RecordType::TXT,
         RecordClass::Internet,
@@ -141,19 +141,19 @@ async fn test_db_create_records() -> Result<(), GoatNsError> {
 /// test all the things
 #[tokio::test]
 async fn test_all_db_things() -> Result<(), GoatNsError> {
-    let pool = test_get_sqlite_memory().await;
+    let dbconn = test_get_sqlite_memory().await;
 
     let zone = test_example_com_zone();
 
     println!("Creating a zone");
-    let zone = zone.clone().insert(&pool).await?;
+    let zone = zone.clone().insert(&dbconn).await?;
     println!("Getting a zone!");
 
     println!("Zone: {zone:?}");
 
     let zone_data = entities::zones::Entity::find()
         .filter(entities::zones::Column::Name.eq("example.com".to_string()))
-        .one(&pool)
+        .one(&dbconn)
         .await?
         .expect("Failed to get zone");
     println!("{zone_data:?}");
@@ -170,17 +170,17 @@ async fn test_all_db_things() -> Result<(), GoatNsError> {
         rdata: Set("test txt".to_string()),
     };
     println!("rec to create: {rec_to_create:?}");
-    let saved_record = rec_to_create.insert(&pool).await?;
+    let saved_record = rec_to_create.insert(&dbconn).await?;
     println!("Saved record: {saved_record:?}");
     let saved_record = saved_record.into_active_model();
     // Saving the same record object again should work (it has an ID now so it's an update)
-    if let Err(err) = saved_record.update(&pool).await {
+    if let Err(err) = saved_record.update(&dbconn).await {
         panic!("{err:?}");
     };
 
     println!("Looking for foo.example.com TXT IN");
     let result = entities::records_merged::Entity::get_records(
-        &pool,
+        &dbconn,
         "foo.example.com",
         RecordType::TXT,
         RecordClass::Internet,
@@ -205,13 +205,13 @@ async fn test_create_example_com_zone(
 
 #[tokio::test]
 async fn test_export_zone() -> Result<(), GoatNsError> {
-    let pool = test_get_sqlite_memory().await;
+    let dbconn = test_get_sqlite_memory().await;
     eprintln!("Setting up example zone");
-    let zone = test_create_example_com_zone(&pool).await?;
+    let zone = test_create_example_com_zone(&dbconn).await?;
 
     let records_to_create = 100usize;
     eprintln!("Creating records");
-    if let Err(err) = test_create_example_com_records(&pool, zone.id, records_to_create).await {
+    if let Err(err) = test_create_example_com_records(&dbconn, zone.id, records_to_create).await {
         panic!("failed to create test records: {err:?}");
     }
 
@@ -242,7 +242,7 @@ async fn test_export_zone() -> Result<(), GoatNsError> {
 async fn load_then_export() -> Result<(), GoatNsError> {
     use tokio::io::AsyncReadExt;
     // set up the DB
-    let pool = test_get_sqlite_memory().await;
+    let dbconn = test_get_sqlite_memory().await;
 
     let example_zone_file = std::path::Path::new(&"./examples/test_config/single-zone.json");
 
@@ -251,9 +251,9 @@ async fn load_then_export() -> Result<(), GoatNsError> {
         .inspect_err(|err| println!("Failed to load zone file! {err:?}"))?;
     let zone_name = example_zone.zone.name.clone();
     let am: entities::zones::ActiveModel = example_zone.zone.clone().into();
-    am.insert(&pool).await?;
+    am.insert(&dbconn).await?;
     eprint!("importing zone into db...");
-    import_zonefile(&pool, example_zone).await?;
+    import_zonefile(&dbconn, example_zone).await?;
     // example_zone.insert(&pool).await?;
     eprintln!("done!");
 
@@ -279,7 +279,7 @@ async fn load_then_export() -> Result<(), GoatNsError> {
     eprintln!("Exporting zone");
     let zone_got = entities::zones::Entity::find()
         .filter(entities::zones::Column::Name.eq(zone_name))
-        .one(&pool)
+        .one(&dbconn)
         .await?
         .expect("Failed to get zone from DB");
     eprintln!("zone_got {zone_got:?}");
@@ -289,7 +289,7 @@ async fn load_then_export() -> Result<(), GoatNsError> {
 
 #[tokio::test]
 async fn test_duplicate_record_constraint() -> Result<(), GoatNsError> {
-    let pool = test_get_sqlite_memory().await;
+    let dbconn = test_get_sqlite_memory().await;
 
     // Create a test zone
     let test_zone = entities::zones::ActiveModel {
@@ -303,7 +303,7 @@ async fn test_duplicate_record_constraint() -> Result<(), GoatNsError> {
         minimum: Set(86400),
     };
 
-    let zone = test_zone.insert(&pool).await?;
+    let zone = test_zone.insert(&dbconn).await?;
     let zone_id = zone.id;
 
     // Create the first record
@@ -317,7 +317,7 @@ async fn test_duplicate_record_constraint() -> Result<(), GoatNsError> {
         ttl: Set(Some(300)),
     };
 
-    let record1 = record1.insert(&pool).await?;
+    let record1 = record1.insert(&dbconn).await?;
     println!("Created first record: {record1:?}");
 
     // Try to create a record with same name, type, class but different rdata (should succeed in DNS)
@@ -331,7 +331,7 @@ async fn test_duplicate_record_constraint() -> Result<(), GoatNsError> {
         ttl: Set(Some(300)),
     };
 
-    let record2 = record2.insert(&pool).await?;
+    let record2 = record2.insert(&dbconn).await?;
     println!("Created second record: {record2:?}");
 
     assert_eq!(
@@ -343,7 +343,7 @@ async fn test_duplicate_record_constraint() -> Result<(), GoatNsError> {
     let record3 = record1.into_active_model();
 
     record3
-        .insert(&pool)
+        .insert(&dbconn)
         .await
         .expect_err("Creating duplicate record should fail");
 
@@ -352,7 +352,7 @@ async fn test_duplicate_record_constraint() -> Result<(), GoatNsError> {
 
 #[tokio::test]
 async fn test_record_requires_name() -> Result<(), GoatNsError> {
-    let pool = test_get_sqlite_memory().await;
+    let dbconn = test_get_sqlite_memory().await;
 
     // Create a test zone first
     let test_zone = entities::zones::ActiveModel {
@@ -366,7 +366,7 @@ async fn test_record_requires_name() -> Result<(), GoatNsError> {
         minimum: Set(86400),
     };
 
-    let zone = test_zone.insert(&pool).await?;
+    let zone = test_zone.insert(&dbconn).await?;
 
     // Try to create a record with empty name (now allowed for apex records)
     let record = entities::records::ActiveModel {
@@ -379,7 +379,7 @@ async fn test_record_requires_name() -> Result<(), GoatNsError> {
         ttl: Set(Some(300)),
     };
 
-    let result = record.insert(&pool).await;
+    let result = record.insert(&dbconn).await;
 
     // This should now succeed (empty names are allowed for apex records)
     match result {

--- a/src/resourcerecord.rs
+++ b/src/resourcerecord.rs
@@ -563,7 +563,6 @@ impl TryFrom<entities::records::Model> for InternalResourceRecord {
     }
 }
 
-
 impl TryFrom<entities::records_merged::Model> for InternalResourceRecord {
     type Error = GoatNsError;
     /// This is where we convert from the JSON blob in the file to an internal representation of the data.
@@ -780,7 +779,6 @@ impl TryFrom<entities::records_merged::Model> for InternalResourceRecord {
         }
     }
 }
-
 
 impl PartialEq<RecordClass> for InternalResourceRecord {
     fn eq(&self, other: &RecordClass) -> bool {

--- a/src/servers.rs
+++ b/src/servers.rs
@@ -95,15 +95,22 @@ pub async fn udp_server(
     })?)
     .await
     {
-        Ok(value) => {
-            info!("Started UDP listener on {}:{}", config.address, config.port);
-            value
-        }
+        Ok(value) => value,
         Err(error) => {
             error!("Failed to start UDP listener: {:?}", error);
             return Ok(());
         }
     };
+    udp_server_with_socket(config, datastore_sender, _agent_tx, udp_sock).await
+}
+
+pub async fn udp_server_with_socket(
+    config: CowCellReadTxn<ConfigFile>,
+    datastore_sender: mpsc::Sender<crate::datastore::Command>,
+    _agent_tx: broadcast::Sender<AgentState>,
+    udp_sock: UdpSocket,
+) -> io::Result<()> {
+    info!("Started UDP listener on {}", udp_sock.local_addr()?);
 
     // TODO: this needs to be bigger to handle edns0-negotiated queries
     let mut udp_buffer = [0; UDP_BUFFER_SIZE];
@@ -311,28 +318,28 @@ pub async fn tcp_server(
     agent_tx: broadcast::Sender<AgentState>,
     // mut agent_rx: broadcast::Receiver<AgentState>,
 ) -> io::Result<()> {
-    let mut agent_rx = agent_tx.subscribe();
     let tcpserver = match TcpListener::bind(config.dns_listener_address().map_err(|_err| {
         GoatNsError::StartupError("Failed to get DNS listener address on startup!".to_string())
     })?)
     .await
     {
-        Ok(value) => {
-            info!(
-                "Started TCP listener on {}",
-                config
-                    .dns_listener_address()
-                    .map_err(|_err| GoatNsError::StartupError(
-                        "Failed to get DNS listener address on startup!".to_string()
-                    ))?
-            );
-            value
-        }
+        Ok(value) => value,
         Err(error) => {
             error!("Failed to start TCP Server: {:?}", error);
             return Ok(());
         }
     };
+    tcp_server_with_listener(config, tx, agent_tx, tcpserver).await
+}
+
+pub async fn tcp_server_with_listener(
+    config: CowCellReadTxn<ConfigFile>,
+    tx: mpsc::Sender<crate::datastore::Command>,
+    agent_tx: broadcast::Sender<AgentState>,
+    tcpserver: TcpListener,
+) -> io::Result<()> {
+    let mut agent_rx = agent_tx.subscribe();
+    info!("Started TCP listener on {}", tcpserver.local_addr()?);
 
     let tcp_client_timeout = config.tcp_client_timeout;
     let shutdown_ip_address_list = config.ip_allow_lists.shutdown.to_vec();

--- a/src/tests/cli.rs
+++ b/src/tests/cli.rs
@@ -11,7 +11,7 @@ fn test_default_config_serialization() {
 async fn test_export_zone_file() {
     use crate::tests::test_api::start_test_server;
     let _ = test_logging().await;
-    let (db_connection, servers, _config) = start_test_server().await;
+    let (db_connection, servers, _config, ..) = start_test_server().await;
 
     let tempdir = tempfile::tempdir().expect("failed to create temp dir");
     let output_filename = tempdir.path().join("zone_export.json");

--- a/src/tests/db.rs
+++ b/src/tests/db.rs
@@ -9,9 +9,9 @@ use crate::web::utils::generate_token_key;
 
 #[tokio::test]
 async fn userauthtoken_saves() -> Result<(), GoatNsError> {
-    let pool = test_get_sqlite_memory().await;
+    let dbconn = test_get_sqlite_memory().await;
 
-    let user = create_test_user(&pool).await;
+    let user = create_test_user(&dbconn).await;
 
     println!("Creating UAT Object");
 
@@ -26,17 +26,17 @@ async fn userauthtoken_saves() -> Result<(), GoatNsError> {
     };
     println!("Saving UAT Object to DB: {uat:?}");
 
-    let uat = uat.insert(&pool).await?;
+    let uat = uat.insert(&dbconn).await?;
 
     println!("Saving duplicate UAT Object to DB: {uat:?}");
     let uat2 = uat.clone().into_active_model();
-    uat2.insert(&pool)
+    uat2.insert(&dbconn)
         .await
         .expect_err("Creating a duplicate token value should fail!");
 
     println!("Saving duplicate UAT Object to DB: {uat:?}");
     let uat2 = uat.clone().into_active_model();
-    uat2.insert(&pool)
+    uat2.insert(&dbconn)
         .await
         .expect_err("Creating a duplicate token value should fail!");
 
@@ -46,9 +46,9 @@ async fn userauthtoken_saves() -> Result<(), GoatNsError> {
 }
 #[tokio::test]
 async fn userauthtoken_expiry() -> Result<(), GoatNsError> {
-    let pool = test_get_sqlite_memory().await;
+    let dbconn = test_get_sqlite_memory().await;
 
-    let user = test_harness::create_test_user(&pool).await;
+    let user = test_harness::create_test_user(&dbconn).await;
 
     println!("Creating UAT Objects");
     let tokenhash = "hello world".to_string();
@@ -64,7 +64,7 @@ async fn userauthtoken_expiry() -> Result<(), GoatNsError> {
     };
     println!("Saving UAT Object 1 to DB: {uat:?}");
 
-    uat.insert(&pool).await.expect("Failed to save token");
+    uat.insert(&dbconn).await.expect("Failed to save token");
     let tokenhash = "hello world this should exist".to_string();
     let expiry = Utc::now() + TimeDelta::try_hours(60).expect("how did this fail?");
     let uat = entities::user_tokens::ActiveModel {
@@ -78,16 +78,16 @@ async fn userauthtoken_expiry() -> Result<(), GoatNsError> {
     };
     println!("Saving UAT Object 2 to DB: {uat:?}");
     let _res = uat
-        .insert(&pool)
+        .insert(&dbconn)
         .await
         .expect("Failed to insert second object");
 
     print!("Starting DB Cleanup... ");
-    entities::user_tokens::Entity::cleanup(&pool).await?;
+    entities::user_tokens::Entity::cleanup(&dbconn).await?;
     println!("Done!");
 
     match entities::user_tokens::Entity::find_by_id(1i64)
-        .one(&pool)
+        .one(&dbconn)
         .await?
     {
         Some(uat) => panic!("We shouldn't find this! {uat:?}"),
@@ -96,7 +96,7 @@ async fn userauthtoken_expiry() -> Result<(), GoatNsError> {
 
     assert!(
         entities::user_tokens::Entity::find_by_id(2i64)
-            .one(&pool)
+            .one(&dbconn)
             .await?
             .is_some()
     );
@@ -108,11 +108,11 @@ async fn userauthtoken_expiry() -> Result<(), GoatNsError> {
 
 #[tokio::test]
 async fn test_cron_db_cleanup() -> Result<(), GoatNsError> {
-    let pool = test_get_sqlite_memory().await;
+    let dbconn = test_get_sqlite_memory().await;
 
-    test_harness::create_test_user(&pool).await;
+    test_harness::create_test_user(&dbconn).await;
     println!("doing cleanup");
-    cron_db_cleanup(pool, core::time::Duration::from_micros(100), Some(2)).await;
+    cron_db_cleanup(dbconn, core::time::Duration::from_micros(100), Some(2)).await;
     println!("done with cleanup cycle");
 
     Ok(())
@@ -120,11 +120,11 @@ async fn test_cron_db_cleanup() -> Result<(), GoatNsError> {
 
 #[tokio::test]
 async fn testget_zones_with_txn() -> Result<(), GoatNsError> {
-    let pool = test_get_sqlite_memory().await;
+    let dbconn = test_get_sqlite_memory().await;
 
-    test_harness::create_test_user(&pool).await;
+    test_harness::create_test_user(&dbconn).await;
 
-    let txn = pool.begin().await?;
+    let txn = dbconn.begin().await?;
     let zones = entities::zones::Entity::find()
         .count(&txn)
         .await
@@ -133,9 +133,9 @@ async fn testget_zones_with_txn() -> Result<(), GoatNsError> {
 
     assert_eq!(zones, 0);
 
-    test_harness::import_test_zone_file(&pool).await?;
+    test_harness::import_test_zone_file(&dbconn).await?;
 
-    let txn = pool.begin().await?;
+    let txn = dbconn.begin().await?;
     let zones = entities::zones::Entity::find()
         .count(&txn)
         .await

--- a/src/tests/doh.rs
+++ b/src/tests/doh.rs
@@ -14,7 +14,7 @@ use crate::tests::test_api::start_test_server;
 #[tokio::test]
 async fn test_doh_get_json() -> Result<(), ()> {
     // here we stand up the servers
-    let (pool, _servers, config) = start_test_server().await;
+    let (pool, _servers, config, ..) = start_test_server().await;
 
     let api_port = config.read().await.api_port;
 
@@ -146,7 +146,7 @@ async fn test_doh_get_json() -> Result<(), ()> {
 
 #[tokio::test]
 async fn test_doh_ask_raw_accept() -> Result<(), ()> {
-    let (_pool, _servers, config) = start_test_server().await;
+    let (_pool, _servers, config, ..) = start_test_server().await;
 
     let api_port = config.read().await.api_port;
     let mut headers = reqwest::header::HeaderMap::new();
@@ -182,7 +182,7 @@ async fn test_doh_ask_raw_accept() -> Result<(), ()> {
 
 #[tokio::test]
 async fn test_doh_ask_json_accept() -> Result<(), ()> {
-    let (_pool, _servers, config) = start_test_server().await;
+    let (_pool, _servers, config, ..) = start_test_server().await;
 
     let api_port = config.read().await.api_port;
     let mut headers = reqwest::header::HeaderMap::new();
@@ -219,7 +219,7 @@ async fn test_doh_ask_json_accept() -> Result<(), ()> {
 
 #[tokio::test]
 async fn test_doh_ask_wrong_accept() -> Result<(), ()> {
-    let (_pool, _servers, config) = start_test_server().await;
+    let (_pool, _servers, config, ..) = start_test_server().await;
 
     let api_port = config.read().await.api_port;
     let mut headers = reqwest::header::HeaderMap::new();
@@ -257,7 +257,7 @@ async fn test_doh_ask_wrong_accept() -> Result<(), ()> {
 #[tokio::test]
 async fn test_doh_post_raw_dns() -> Result<(), ()> {
     // here we stand up the servers
-    let (pool, _servers, config) = start_test_server().await;
+    let (pool, _servers, config, ..) = start_test_server().await;
 
     let api_port = config.read().await.api_port;
 
@@ -387,7 +387,7 @@ async fn test_doh_post_raw_dns() -> Result<(), ()> {
 #[tokio::test]
 async fn test_doh_nxdomain_response() -> Result<(), ()> {
     // Test DoH response for non-existent domain
-    let (_pool, _servers, config) = start_test_server().await;
+    let (_pool, _servers, config, ..) = start_test_server().await;
 
     let api_port = config.read().await.api_port;
 
@@ -453,7 +453,7 @@ async fn test_doh_nxdomain_response() -> Result<(), ()> {
 #[tokio::test]
 async fn test_doh_multiple_records() -> Result<(), ()> {
     // Test DoH response with multiple A records for the same name
-    let (pool, _servers, config) = start_test_server().await;
+    let (pool, _servers, config, ..) = start_test_server().await;
 
     let api_port = config.read().await.api_port;
 
@@ -565,7 +565,7 @@ async fn test_doh_multiple_records() -> Result<(), ()> {
 #[tokio::test]
 async fn test_doh_query_parameter_validation() -> Result<(), ()> {
     // Test DoH parameter validation
-    let (_pool, _servers, config) = start_test_server().await;
+    let (_pool, _servers, config, ..) = start_test_server().await;
 
     let api_port = config.read().await.api_port;
 
@@ -624,7 +624,7 @@ async fn test_doh_query_parameter_validation() -> Result<(), ()> {
 #[tokio::test]
 async fn test_doh_different_record_types() -> Result<(), ()> {
     // Test DoH with different DNS record types
-    let (pool, _servers, config) = start_test_server().await;
+    let (pool, _servers, config, ..) = start_test_server().await;
 
     let api_port = config.read().await.api_port;
 

--- a/src/tests/e2e_test.rs
+++ b/src/tests/e2e_test.rs
@@ -113,10 +113,7 @@ mod tests {
 
         // Construct a new Resolver pointing at localhost
         let mut resolver_config = ResolverConfig::new();
-        resolver_config.add_name_server(NameServerConfig::new(
-            dns_addr,
-            Protocol::Udp,
-        ));
+        resolver_config.add_name_server(NameServerConfig::new(dns_addr, Protocol::Udp));
         let resolver =
             Resolver::builder_with_config(resolver_config, TokioConnectionProvider::default())
                 .build();

--- a/src/tests/e2e_test.rs
+++ b/src/tests/e2e_test.rs
@@ -10,7 +10,6 @@ mod tests {
 
     use crate::enums::RecordType;
     use crate::logging::test_logging;
-    use crate::servers::udp_server;
     use crate::tests::utils::wait_for_server;
 
     fn in_github_actions() -> bool {
@@ -36,12 +35,28 @@ mod tests {
         let db_path = tempfile::tempdir()?;
         println!("Using temp dir for db path: {}", db_path.path().display());
         let mut cw = config.write().await;
+        let udp_socket = tokio::net::UdpSocket::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("failed to bind test UDP listener");
+        let dns_addr = udp_socket
+            .local_addr()
+            .expect("failed to inspect test UDP listener");
+        let api_listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .expect("failed to bind test API listener");
+        let api_addr = api_listener
+            .local_addr()
+            .expect("failed to inspect test API listener");
+        api_listener
+            .set_nonblocking(true)
+            .expect("failed to set test API listener nonblocking");
 
         cw.db_path = db_path
             .path()
             .with_file_name("goatns-test-e2e.db")
             .display()
             .to_string();
+        cw.port = dns_addr.port();
+        cw.api_port = api_addr.port();
         cw.commit().await;
 
         println!("{:?}", config.read().await);
@@ -50,10 +65,11 @@ mod tests {
         let (agent_sender, datastore_tx, datastore_rx) = crate::utils::start_channels();
 
         println!("Starting UDP server");
-        let udpserver = tokio::spawn(udp_server(
+        let udpserver = tokio::spawn(crate::servers::udp_server_with_socket(
             config.read().await,
             datastore_tx.clone(),
             agent_sender.clone(),
+            udp_socket,
         ));
 
         println!(
@@ -76,11 +92,12 @@ mod tests {
 
         info!("Starting API Server");
         let (_apiserver_tx, apiserver_rx) = tokio::sync::mpsc::channel(5);
-        let apiserver = crate::web::build(
+        let apiserver = crate::web::build_with_listener(
             datastore_tx.clone(),
             apiserver_rx,
             config.read().await,
             connpool.clone(),
+            api_listener,
         )
         .await
         .expect("Failed to build API server");
@@ -95,11 +112,9 @@ mod tests {
         wait_for_server(status_url).await;
 
         // Construct a new Resolver pointing at localhost
-        let localhost: std::net::IpAddr =
-            "127.0.0.1".parse().expect("Failed to parse localhost IP");
         let mut resolver_config = ResolverConfig::new();
         resolver_config.add_name_server(NameServerConfig::new(
-            SocketAddr::new(localhost, 15353),
+            dns_addr,
             Protocol::Udp,
         ));
         let resolver =

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -667,14 +667,14 @@ async fn test_question_from_bytes() {
 /// this test checks that all TTLs in the record are the same when we set normalise_ttls = true
 async fn test_normalize_ttls() {
     test_logging().await;
-    let pool = test_get_sqlite_memory().await;
+    let dbconn = test_get_sqlite_memory().await;
 
-    import_test_zone_file(&pool)
+    import_test_zone_file(&dbconn)
         .await
         .expect("failed to import test zone file");
 
     let response = entities::records_merged::Entity::get_records(
-        &pool,
+        &dbconn,
         "ttltest.hello.goat",
         RecordType::A,
         RecordClass::Internet,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -711,14 +711,14 @@ async fn test_normalize_ttls() {
 /// this test checks that all TTLs in the record are the same when we set normalise_ttls = true
 async fn test_dont_normalize_ttls() {
     // use crate::zones::FileZoneRecord;
-    let pool = test_get_sqlite_memory().await;
+    let dbconn = test_get_sqlite_memory().await;
 
-    import_test_zone_file(&pool)
+    import_test_zone_file(&dbconn)
         .await
         .expect("Failed to import zone file");
 
     let response = entities::records_merged::Entity::get_records(
-        &pool,
+        &dbconn,
         "ttltest.hello.goat",
         RecordType::A,
         RecordClass::Internet,

--- a/src/tests/test_api.rs
+++ b/src/tests/test_api.rs
@@ -3,6 +3,7 @@ use super::prelude::*;
 use crate::config::ConfigFile;
 use crate::servers::{self, Servers};
 use crate::web::api::auth::AuthPayload;
+use crate::web::api::docs::ApiDoc;
 use crate::web::api::records::RecordForm;
 use crate::web::api::zones::ZoneForm;
 use crate::web::utils::create_api_token;
@@ -11,6 +12,7 @@ use log::info;
 use reqwest::StatusCode;
 use sea_orm::EntityTrait;
 use tokio::net::{TcpListener, UdpSocket};
+use utoipa::OpenApi;
 
 pub async fn is_free_port(port: u16) -> bool {
     let addr = ("127.0.0.1", port);
@@ -203,6 +205,109 @@ async fn api_zone_create() -> Result<(), GoatNsError> {
     assert_eq!(response_zone.serial, 12345);
     assert_ne!(response_zone.serial, 123456);
     drop(pool);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn swagger_ui_and_openapi_are_served() -> Result<(), GoatNsError> {
+    let (_pool, _servers, config) = start_test_server().await;
+    let api_port = config.read().await.api_port;
+
+    let no_redirect_client = reqwest::ClientBuilder::new()
+        .danger_accept_invalid_certs(true)
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .expect("Failed to build no-redirect client");
+
+    let redirect_response = no_redirect_client
+        .get(format!("https://localhost:{api_port}/api/docs"))
+        .send()
+        .await
+        .expect("Failed to fetch Swagger redirect");
+    assert_eq!(redirect_response.status(), StatusCode::SEE_OTHER);
+    assert_eq!(
+        redirect_response
+            .headers()
+            .get(reqwest::header::LOCATION)
+            .expect("Missing redirect location"),
+        "/api/docs/"
+    );
+
+    let client = reqwest::ClientBuilder::new()
+        .danger_accept_invalid_certs(true)
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .expect("Failed to build client");
+
+    let docs_response = client
+        .get(format!("https://localhost:{api_port}/api/docs/"))
+        .send()
+        .await
+        .expect("Failed to fetch Swagger UI");
+    assert_eq!(docs_response.status(), StatusCode::OK);
+    let docs_html = docs_response
+        .text()
+        .await
+        .expect("Failed to read Swagger UI response");
+    assert!(
+        docs_html.contains("<title>Swagger UI</title>"),
+        "Swagger UI title missing"
+    );
+    assert!(
+        docs_html.contains("swagger-initializer.js"),
+        "Swagger UI bootstrap missing"
+    );
+
+    let openapi_response = client
+        .get(format!("https://localhost:{api_port}/api/openapi.json"))
+        .send()
+        .await
+        .expect("Failed to fetch OpenAPI document");
+    assert_eq!(openapi_response.status(), StatusCode::OK);
+    let openapi_json = openapi_response
+        .text()
+        .await
+        .expect("Failed to read OpenAPI response");
+
+    for expected_path in [
+        "/api/login",
+        "/api/record",
+        "/api/record/{record_id}",
+        "/api/zone",
+        "/api/zone/{zone_id}",
+    ] {
+        assert!(
+            openapi_json.contains(&format!("\"{expected_path}\"")),
+            "Missing OpenAPI path {expected_path}"
+        );
+    }
+
+    for expected_operation in [
+        "\"operationId\":\"login\"",
+        "\"operationId\":\"record_create\"",
+        "\"operationId\":\"record_update\"",
+        "\"operationId\":\"record_get\"",
+        "\"operationId\":\"record_delete\"",
+        "\"operationId\":\"zone_create\"",
+        "\"operationId\":\"zone_update\"",
+        "\"operationId\":\"zone_get\"",
+        "\"operationId\":\"zone_delete\"",
+    ] {
+        assert!(
+            openapi_json.contains(expected_operation),
+            "Missing OpenAPI operation {expected_operation}"
+        );
+    }
+
+    let generated_openapi = ApiDoc::openapi()
+        .to_pretty_json()
+        .expect("Failed to serialise OpenAPI document");
+    assert!(
+        generated_openapi.contains("\"/api/zone/{zone_id}\""),
+        "Generated OpenAPI should include zone detail route"
+    );
+
     Ok(())
 }
 

--- a/src/tests/test_api.rs
+++ b/src/tests/test_api.rs
@@ -11,92 +11,95 @@ use concread::cowcell::asynch::CowCell;
 use log::info;
 use reqwest::StatusCode;
 use sea_orm::EntityTrait;
+use std::net::{Ipv4Addr, SocketAddr};
 use tokio::net::{TcpListener, UdpSocket};
 use utoipa::OpenApi;
 
-pub async fn is_free_port(port: u16) -> bool {
-    let addr = ("127.0.0.1", port);
-    let tcp_listener = TcpListener::bind(addr).await;
-    if tcp_listener.is_err() {
-        return false;
-    }
+async fn bind_test_dns_listeners() -> (TcpListener, UdpSocket, SocketAddr) {
+    loop {
+        let tcp_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("failed to bind DNS TCP test listener");
+        let dns_addr = tcp_listener
+            .local_addr()
+            .expect("failed to inspect DNS TCP test listener");
 
-    let udp_listener = UdpSocket::bind(addr).await;
-    if udp_listener.is_err() {
-        return false;
+        match UdpSocket::bind((Ipv4Addr::LOCALHOST, dns_addr.port())).await {
+            Ok(udp_socket) => return (tcp_listener, udp_socket, dns_addr),
+            Err(_) => drop(tcp_listener),
+        }
     }
-
-    true
 }
 
-pub async fn start_test_server() -> (DatabaseConnection, Servers, CowCell<ConfigFile>) {
+pub async fn start_test_server() -> (
+    DatabaseConnection,
+    Servers,
+    CowCell<ConfigFile>,
+    SocketAddr,
+    SocketAddr,
+) {
     test_logging().await;
-    let pool = test_get_sqlite_memory().await;
+    let dbconn = test_get_sqlite_memory().await;
 
     let config = crate::config::ConfigFile::try_as_cowcell(Some(
         "./examples/test_config/goatns-test.json".to_string(),
     ))
     .expect("failed to parse test config");
 
-    use rand::Rng;
-    let mut rng = rand::rng();
-    let mut api_port: u16 = rng.random_range(2000..=65000);
-    loop {
-        if is_free_port(api_port).await {
-            break;
-        }
-        api_port = rng.random_range(2000..=65000);
-    }
-
-    let mut dns_port: u16 = rng.random_range(2000..=65000);
-    loop {
-        if dns_port != api_port && is_free_port(dns_port).await {
-            break;
-        }
-        dns_port = rng.random_range(2000..=65000);
-    }
+    let api_listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .expect("failed to bind API test listener");
+    let api_addr = api_listener
+        .local_addr()
+        .expect("failed to inspect API test listener");
+    api_listener
+        .set_nonblocking(true)
+        .expect("failed to set API test listener nonblocking");
+    let (dns_tcp_listener, dns_udp_socket, dns_addr) = bind_test_dns_listeners().await;
 
     let mut config_tx = config.write().await;
-    config_tx.api_port = api_port;
-    config_tx.port = dns_port;
+    config_tx.api_port = api_addr.port();
+    config_tx.port = dns_addr.port();
     config_tx.commit().await;
 
     // println!("Starting channels");
     let (agent_sender, datastore_tx, datastore_rx) = crate::utils::start_channels();
 
-    let udpserver = tokio::spawn(servers::udp_server(
+    let udpserver = tokio::spawn(servers::udp_server_with_socket(
         config.read().await,
         datastore_tx.clone(),
         agent_sender.clone(),
+        dns_udp_socket,
     ));
-    let tcpserver = tokio::spawn(servers::tcp_server(
+    let tcpserver = tokio::spawn(servers::tcp_server_with_listener(
         config.read().await,
         datastore_tx.clone(),
         agent_sender.clone(),
+        dns_tcp_listener,
     ));
     // start all the things!
     let datastore_manager = tokio::spawn(crate::datastore::manager(
         datastore_rx,
         "test.goatns.goat".to_string(),
-        pool.clone(),
+        dbconn.clone(),
         None,
     ));
 
-    info!("Starting API Server on port {api_port}");
+    info!("Starting API Server on port {}", api_addr.port());
     let (_apiserver_tx, apiserver_rx) = tokio::sync::mpsc::channel(5);
 
-    let apiserver = crate::web::build(
+    let apiserver = crate::web::build_with_listener(
         datastore_tx.clone(),
         apiserver_rx,
         config.read().await,
-        pool.clone(),
+        dbconn.clone(),
+        api_listener,
     )
     .await
     .expect("Failed to start API server");
 
     println!("Building server struct");
     let res = (
-        pool,
+        dbconn,
         crate::servers::Servers::build(agent_sender)
             .with_apiserver(apiserver)
             .with_datastore(datastore_manager)
@@ -104,6 +107,8 @@ pub async fn start_test_server() -> (DatabaseConnection, Servers, CowCell<Config
             .with_tcpserver(tcpserver)
             .with_datastore_tx(datastore_tx),
         config,
+        api_addr,
+        dns_addr,
     );
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
     res
@@ -140,7 +145,7 @@ async fn insert_test_user_api_token(
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn api_zone_create() -> Result<(), GoatNsError> {
     // here we stand up the servers
-    let (pool, _servers, config) = start_test_server().await;
+    let (pool, _servers, config, ..) = start_test_server().await;
 
     let api_port = config.read().await.api_port;
 
@@ -210,7 +215,7 @@ async fn api_zone_create() -> Result<(), GoatNsError> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn swagger_ui_and_openapi_are_served() -> Result<(), GoatNsError> {
-    let (_pool, _servers, config) = start_test_server().await;
+    let (_pool, _servers, config, ..) = start_test_server().await;
     let api_port = config.read().await.api_port;
 
     let no_redirect_client = reqwest::ClientBuilder::new()
@@ -314,7 +319,7 @@ async fn swagger_ui_and_openapi_are_served() -> Result<(), GoatNsError> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn api_zone_create_delete() -> Result<(), sqlx::Error> {
     // here we stand up the servers
-    let (pool, _servers, config) = start_test_server().await;
+    let (pool, _servers, config, ..) = start_test_server().await;
 
     let api_port = config.read().await.api_port;
 
@@ -398,7 +403,7 @@ async fn api_zone_create_delete() -> Result<(), sqlx::Error> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn api_zone_create_update() -> Result<(), GoatNsError> {
     // here we stand up the servers
-    let (pool, _servers, config) = start_test_server().await;
+    let (pool, _servers, config, ..) = start_test_server().await;
 
     let api_port = config.read().await.api_port;
 
@@ -478,7 +483,7 @@ async fn api_zone_create_update() -> Result<(), GoatNsError> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn api_record_create() -> Result<(), GoatNsError> {
     // here we stand up the servers
-    let (pool, _servers, config) = start_test_server().await;
+    let (pool, _servers, config, ..) = start_test_server().await;
     let api_port = config.read().await.api_port;
     let user = insert_test_user(&pool).await;
     println!("Created user... {user:?}");
@@ -567,7 +572,7 @@ async fn api_record_create() -> Result<(), GoatNsError> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn api_record_delete() -> Result<(), GoatNsError> {
     // here we stand up the servers
-    let (pool, _servers, config) = start_test_server().await;
+    let (pool, _servers, config, ..) = start_test_server().await;
     let api_port = config.read().await.api_port;
     let user = insert_test_user(&pool).await;
     println!("Created user... {user:?}");
@@ -670,7 +675,7 @@ async fn api_record_delete() -> Result<(), GoatNsError> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn api_record_delete_forbidden_without_ownership() -> Result<(), GoatNsError> {
-    let (pool, _servers, config) = start_test_server().await;
+    let (pool, _servers, config, ..) = start_test_server().await;
     let api_port = config.read().await.api_port;
 
     let owner = insert_test_user(&pool).await;
@@ -760,7 +765,7 @@ async fn api_record_delete_forbidden_without_ownership() -> Result<(), GoatNsErr
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn api_record_get_forbidden_without_ownership() -> Result<(), GoatNsError> {
-    let (pool, _servers, config) = start_test_server().await;
+    let (pool, _servers, config, ..) = start_test_server().await;
     let api_port = config.read().await.api_port;
 
     let owner = insert_test_user(&pool).await;
@@ -845,7 +850,7 @@ async fn api_record_get_forbidden_without_ownership() -> Result<(), GoatNsError>
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn api_record_get_requires_auth() -> Result<(), GoatNsError> {
-    let (pool, _servers, config) = start_test_server().await;
+    let (pool, _servers, config, ..) = start_test_server().await;
     let api_port = config.read().await.api_port;
 
     let user = insert_test_user(&pool).await;
@@ -909,7 +914,7 @@ async fn api_record_get_requires_auth() -> Result<(), GoatNsError> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn api_record_delete_requires_auth() -> Result<(), GoatNsError> {
-    let (pool, _servers, config) = start_test_server().await;
+    let (pool, _servers, config, ..) = start_test_server().await;
     let api_port = config.read().await.api_port;
 
     let user = insert_test_user(&pool).await;
@@ -978,7 +983,7 @@ async fn api_record_delete_requires_auth() -> Result<(), GoatNsError> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn api_record_delete_does_not_delete_zone() -> Result<(), GoatNsError> {
-    let (pool, _servers, config) = start_test_server().await;
+    let (pool, _servers, config, ..) = start_test_server().await;
     let api_port = config.read().await.api_port;
 
     let user = insert_test_user(&pool).await;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
+use crate::HEADER_BYTES;
 use crate::enums::AgentState;
 use crate::error::GoatNsError;
-use crate::HEADER_BYTES;
 use crate::{datastore::Command, resourcerecord::NameAsBytes};
 use std::cmp::min;
 use std::str::from_utf8;

--- a/src/web/api/docs.rs
+++ b/src/web/api/docs.rs
@@ -1,21 +1,34 @@
-use crate::{RecordClass, web::api::records::RecordForm};
-use utoipa::{Modify, OpenApi};
+use crate::{RecordClass, RecordType};
+use utoipa::OpenApi;
 
 #[derive(OpenApi)]
 #[openapi(
     paths(
         super::auth::api_token_login,
         super::records::api_record_create,
+        super::records::api_record_update,
+        super::records::api_record_get,
+        super::records::api_record_delete,
+        super::zones::api_zone_create,
+        super::zones::api_zone_update,
+        super::zones::api_get,
+        super::zones::api_zone_delete,
     ),
     components(
         schemas(
             super::auth::AuthPayload,
             super::auth::AuthResponse,
-            RecordForm,
+            super::records::ApiRecordUpdate,
+            super::records::RecordForm,
+            super::zones::ApiZoneResponse,
+            super::zones::ZoneForm,
+            super::zones::ZoneUpdate,
+            crate::db::entities::records::Model,
+            crate::db::entities::zones::Model,
             RecordClass,
+            RecordType,
         )
     ),
-    modifiers(&SecurityAddon),
     tags(
         (name = "Authentication", description = "Authentication-related tasks"),
         (name = "Records", description = "DNS Record operations"),
@@ -24,17 +37,3 @@ use utoipa::{Modify, OpenApi};
 )]
 #[allow(dead_code)]
 pub(crate) struct ApiDoc;
-
-#[allow(dead_code)]
-pub(crate) struct SecurityAddon;
-
-impl Modify for SecurityAddon {
-    fn modify(&self, _openapi: &mut utoipa::openapi::OpenApi) {
-        // if let Some(components) = openapi.components.as_mut() {
-        //     components.add_security_scheme(
-        //         "api_key",
-        //         SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::new("todo_apikey"))),
-        //     )
-        // }
-    }
-}

--- a/src/web/api/mod.rs
+++ b/src/web/api/mod.rs
@@ -1,5 +1,6 @@
 use axum::{Router, routing::get};
 use prelude::*;
+use utoipa::ToSchema;
 pub mod auth;
 pub(crate) mod docs;
 pub(crate) mod prelude;
@@ -19,7 +20,7 @@ impl Default for NotImplemented {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
 #[allow(dead_code)]
 pub struct ErrorResult {
     #[allow(dead_code)]

--- a/src/web/api/records.rs
+++ b/src/web/api/records.rs
@@ -188,11 +188,12 @@ pub struct ApiRecordUpdate {
     put,
     path = "/api/record",
     operation_id = "record_update",
-    request_body = entities::records::Model,
+    request_body = ApiRecordUpdate,
     responses(
-        (status = 200, description = "Successful"),
-        (status = 403, description = "Auth failed"),
-        (status = 500, description = "Something broke!"),
+        (status = 200, description = "Successful", body = entities::records::Model),
+        (status = 403, description = "Auth failed", body = ErrorResult),
+        (status = 404, description = "Record not found", body = ErrorResult),
+        (status = 500, description = "Something broke!", body = ErrorResult),
     ),
     tag = "Records",
 )]
@@ -294,6 +295,22 @@ pub(crate) async fn api_record_update(
         Ok(Json(res))
     }
 }
+
+#[utoipa::path(
+    get,
+    path = "/api/record/{record_id}",
+    operation_id = "record_get",
+    params(
+        ("record_id" = Uuid, Path, description = "Record ID")
+    ),
+    responses(
+        (status = 200, description = "Successful", body = entities::records::Model),
+        (status = 403, description = "Auth failed", body = ErrorResult),
+        (status = 404, description = "Record not found", body = ErrorResult),
+        (status = 500, description = "Something broke!", body = ErrorResult),
+    ),
+    tag = "Records",
+)]
 pub(crate) async fn api_record_get(
     State(state): State<GoatState>,
     session: Session,
@@ -352,6 +369,21 @@ pub(crate) async fn api_record_get(
 
 /// Delete an object
 /// <https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE>
+#[utoipa::path(
+    delete,
+    path = "/api/record/{record_id}",
+    operation_id = "record_delete",
+    params(
+        ("record_id" = Uuid, Path, description = "Record ID")
+    ),
+    responses(
+        (status = 200, description = "Successful"),
+        (status = 403, description = "Auth failed", body = ErrorResult),
+        (status = 404, description = "Record not found", body = ErrorResult),
+        (status = 500, description = "Something broke!", body = ErrorResult),
+    ),
+    tag = "Records",
+)]
 pub(crate) async fn api_record_delete(
     State(state): State<GoatState>,
     session: Session,

--- a/src/web/api/zones.rs
+++ b/src/web/api/zones.rs
@@ -50,7 +50,7 @@ pub struct FileZoneResponse {
     pub id: Option<i64>,
 }
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, ToSchema)]
 pub struct ApiZoneResponse {
     #[serde(flatten)]
     pub zone: entities::zones::Model,
@@ -68,13 +68,18 @@ impl From<entities::zones::Model> for ApiZoneResponse {
 }
 
 #[utoipa::path(
-    method(post),
+    post,
     path = "/api/zone",
+    operation_id = "zone_create",
+    request_body = ZoneForm,
     responses(
-        (status = OK, description = "Success", body = str, content_type = "text/plain")
-    )
+        (status = 200, description = "Successful", body = ApiZoneResponse),
+        (status = 400, description = "Validation failed", body = ErrorResult),
+        (status = 403, description = "Auth failed", body = ErrorResult),
+        (status = 500, description = "Something broke!", body = ErrorResult),
+    ),
+    tag = "Zones",
 )]
-
 pub(crate) async fn api_zone_create(
     State(state): State<GoatState>,
     session: Session,
@@ -171,7 +176,7 @@ pub(crate) async fn api_zone_create(
     Ok(Json(zone.into()))
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub(crate) struct ZoneUpdate {
     pub id: Uuid,
     pub rname: Option<String>,
@@ -182,6 +187,18 @@ pub(crate) struct ZoneUpdate {
     pub minimum: Option<u32>,
 }
 
+#[utoipa::path(
+    put,
+    path = "/api/zone",
+    operation_id = "zone_update",
+    request_body = ZoneUpdate,
+    responses(
+        (status = 200, description = "Successful", body = String),
+        (status = 401, description = "Not authorized", body = ErrorResult),
+        (status = 500, description = "Something broke!", body = ErrorResult),
+    ),
+    tag = "Zones",
+)]
 pub(crate) async fn api_zone_update(
     State(state): State<GoatState>,
     session: Session,
@@ -282,6 +299,20 @@ pub(crate) async fn api_zone_update(
     }
 }
 
+#[utoipa::path(
+    delete,
+    path = "/api/zone/{zone_id}",
+    operation_id = "zone_delete",
+    params(
+        ("zone_id" = Uuid, Path, description = "Zone ID")
+    ),
+    responses(
+        (status = 200, description = "Successful"),
+        (status = 404, description = "Zone not found", body = ErrorResult),
+        (status = 500, description = "Something broke!", body = ErrorResult),
+    ),
+    tag = "Zones",
+)]
 pub(crate) async fn api_zone_delete(
     State(state): State<GoatState>,
     session: Session,
@@ -358,6 +389,21 @@ pub(crate) async fn api_zone_delete(
     Ok(StatusCode::OK)
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/zone/{zone_id}",
+    operation_id = "zone_get",
+    params(
+        ("zone_id" = Uuid, Path, description = "Zone ID")
+    ),
+    responses(
+        (status = 200, description = "Successful", body = ApiZoneResponse),
+        (status = 403, description = "Auth failed", body = ErrorResult),
+        (status = 404, description = "Zone not found", body = ErrorResult),
+        (status = 500, description = "Something broke!", body = ErrorResult),
+    ),
+    tag = "Zones",
+)]
 pub(crate) async fn api_get(
     State(state): State<GoatState>,
     session: Session,

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -32,6 +32,7 @@ use sea_orm::TransactionTrait;
 use utoipa::OpenApi;
 
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
@@ -251,45 +252,63 @@ pub async fn build(
     config: CowCellReadTxn<ConfigFile>,
     connpool: DatabaseConnection,
 ) -> Result<JoinHandle<Result<(), std::io::Error>>, GoatNsError> {
-    let router = build_router(tx, config.clone(), connpool).await?;
     let listener_address = config.api_listener_address()?;
-    let hostname = config.hostname.clone();
-    let api_port = config.api_port;
-    let mut rx = rx;
+    let listener = std::net::TcpListener::bind(listener_address)
+        .map_err(|err| GoatNsError::StartupError(format!("Failed to bind API listener: {err}")))?;
+    listener
+        .set_nonblocking(true)
+        .map_err(|err| GoatNsError::StartupError(format!("Failed to set API listener nonblocking: {err}")))?;
+    build_with_listener(tx, rx, config, connpool, listener).await
+}
 
-    let loop_config = config.clone();
+pub async fn build_with_listener(
+    tx: Sender<datastore::Command>,
+    rx: Receiver<ServerCommand>,
+    config: CowCellReadTxn<ConfigFile>,
+    connpool: DatabaseConnection,
+    listener: std::net::TcpListener,
+) -> Result<JoinHandle<Result<(), std::io::Error>>, GoatNsError> {
+    let router = build_router(tx, config.clone(), connpool).await?;
+    let listener_address: SocketAddr = listener
+        .local_addr()
+        .map_err(|err| GoatNsError::StartupError(format!("Failed to inspect API listener: {err}")))?;
+    let hostname = config.hostname.clone();
+    let mut rx = rx;
     let res: JoinHandle<Result<(), std::io::Error>> = tokio::spawn(async move {
+        let tls_config = config
+            .get_tls_config()
+            .await
+            .map_err(std::io::Error::other)?;
+        let handle = axum_server::Handle::new();
+        let server = axum_server::from_tcp_rustls(listener, tls_config)?
+            .handle(handle.clone())
+            .serve(router.into_make_service());
+        tokio::pin!(server);
+
         loop {
-            let tls_config = loop_config
-                .get_tls_config()
-                .await
-                .map_err(GoatNsError::StartupError)?;
             tokio::select! {
-                Some(action) = rx.recv() => {
-                    match action {
-                        ServerCommand::ReloadTls => {
-                            info!("Reloading TLS configuration.");
-                            continue;
-                        }
-                        ServerCommand::ShutDown => {
-                            info!("Shutting down web server.");
-                            return Ok(());
-                        }
+                Some(action) = rx.recv() => match action {
+                    ServerCommand::ReloadTls => {
+                        warn!("Ignoring TLS reload for pre-bound API listener");
                     }
+                    ServerCommand::ShutDown => {
+                        info!("Shutting down web server.");
+                        handle.shutdown();
+                    }
+                },
+                res = &mut server => {
+                    if let Err(err) = res {
+                        error!("Web server error: {}", err);
+                        return Err(err);
+                    }
+                    return Ok(());
                 }
-                res = axum_server::bind_rustls(loop_config.api_listener_address()?, tls_config)
-                    .serve(router.clone().into_make_service()) => {
-                        if let Err(err) = res {
-                            error!("Web server error: {}", err);
-                            return Err(err);
-                        }
-                    }
             }
         }
     });
     let startup_message = format!(
         "Started Web server on https://{} / https://{}:{}",
-        listener_address, hostname, api_port
+        listener_address, hostname, listener_address.port()
     );
 
     #[cfg(test)]

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -255,9 +255,9 @@ pub async fn build(
     let listener_address = config.api_listener_address()?;
     let listener = std::net::TcpListener::bind(listener_address)
         .map_err(|err| GoatNsError::StartupError(format!("Failed to bind API listener: {err}")))?;
-    listener
-        .set_nonblocking(true)
-        .map_err(|err| GoatNsError::StartupError(format!("Failed to set API listener nonblocking: {err}")))?;
+    listener.set_nonblocking(true).map_err(|err| {
+        GoatNsError::StartupError(format!("Failed to set API listener nonblocking: {err}"))
+    })?;
     build_with_listener(tx, rx, config, connpool, listener).await
 }
 
@@ -269,18 +269,20 @@ pub async fn build_with_listener(
     listener: std::net::TcpListener,
 ) -> Result<JoinHandle<Result<(), std::io::Error>>, GoatNsError> {
     let router = build_router(tx, config.clone(), connpool).await?;
-    let listener_address: SocketAddr = listener
-        .local_addr()
-        .map_err(|err| GoatNsError::StartupError(format!("Failed to inspect API listener: {err}")))?;
+    let listener_address: SocketAddr = listener.local_addr().map_err(|err| {
+        GoatNsError::StartupError(format!("Failed to inspect API listener: {err}"))
+    })?;
     let hostname = config.hostname.clone();
+    let tls_cert = config.api_tls_cert.clone();
+    let tls_key = config.api_tls_key.clone();
+    let tls_config = config
+        .get_tls_config()
+        .await
+        .map_err(GoatNsError::StartupError)?;
     let mut rx = rx;
     let res: JoinHandle<Result<(), std::io::Error>> = tokio::spawn(async move {
-        let tls_config = config
-            .get_tls_config()
-            .await
-            .map_err(std::io::Error::other)?;
         let handle = axum_server::Handle::new();
-        let server = axum_server::from_tcp_rustls(listener, tls_config)?
+        let server = axum_server::from_tcp_rustls(listener, tls_config.clone())?
             .handle(handle.clone())
             .serve(router.into_make_service());
         tokio::pin!(server);
@@ -289,7 +291,14 @@ pub async fn build_with_listener(
             tokio::select! {
                 Some(action) = rx.recv() => match action {
                     ServerCommand::ReloadTls => {
-                        warn!("Ignoring TLS reload for pre-bound API listener");
+                        match tls_config.reload_from_pem_file(&tls_cert, &tls_key).await {
+                            Ok(()) => {
+                                info!("Reloaded TLS configuration for API listener.");
+                            }
+                            Err(err) => {
+                                error!("Failed to reload TLS configuration: {err}");
+                            }
+                        }
                     }
                     ServerCommand::ShutDown => {
                         info!("Shutting down web server.");
@@ -308,7 +317,9 @@ pub async fn build_with_listener(
     });
     let startup_message = format!(
         "Started Web server on https://{} / https://{}:{}",
-        listener_address, hostname, listener_address.port()
+        listener_address,
+        hostname,
+        listener_address.port()
     );
 
     #[cfg(test)]


### PR DESCRIPTION
## Summary
- replace test port probing with listener-based startup using bound TCP and UDP sockets
- add listener-driven server entrypoints for the web API and DNS servers while keeping the config-driven startup paths
- expand OpenAPI and Swagger coverage for record and zone endpoints, including new API docs checks in the test suite
- restore TLS certificate reloads for the pre-bound API listener so runtime cert rotation still works
- simplify and stabilize the shared test setup by binding listeners up front and reusing the assigned addresses