### PR TITLE
Add DNSSEC record serving, EDNS0/OPT support, and security hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,9 +66,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -81,15 +81,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -158,9 +158,9 @@ checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "askama"
@@ -189,7 +189,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_derive",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -201,7 +201,7 @@ dependencies = [
  "memchr",
  "serde",
  "serde_derive",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -225,14 +225,14 @@ checksum = "34921de3d57974069bad483fdfe0ec65d88c4ff892edd1ab4d8b03be0dda1b9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "async-compression"
-version = "0.4.37"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d10e4f991a553474232bc0a31799f6d24b034a84c0971d80d2e2f78b2e576e40"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -259,7 +259,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -270,7 +270,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -290,15 +290,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.2"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88aab2464f1f25453baa7a07c84c5b7684e274054ba06817f382357f77a288"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -306,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.35.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45afffdee1e7c9126814751f88dddc747f41d91da16c9551a0f1e8a11e788a1"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "axum-macros",
@@ -403,13 +403,13 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -513,18 +513,18 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -552,32 +552,33 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
 dependencies = [
  "borsh-derive",
+ "bytes",
  "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecheck"
@@ -609,9 +610,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cast"
@@ -621,9 +622,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.52"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -645,9 +646,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -696,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -706,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -718,42 +719,42 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.36"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00828ba6fd27b45a448e57dbfe84f1029d4c9f26b368157e9a448a5f49a2ec2a"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "compression-core",
  "flate2",
@@ -762,15 +763,15 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concread"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59bdad7f183b180e608debcf5147cf2afd11c66615fc2b70bccac4844bbaf275"
+checksum = "6588e9e68e11207fb9a5aabd88765187969e6bcba98763c40bcad87b2a73e9f5"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-queue",
@@ -794,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.15.19"
+version = "0.15.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30fa8254caad766fc03cb0ccae691e14bf3bd72bfff27f72802ce729551b3d6"
+checksum = "0b34d0237145f33580b89724f75d16950efd3e2c91b2d823917ecb69ec7f84f0"
 dependencies = [
  "async-trait",
  "convert_case",
@@ -808,19 +809,18 @@ dependencies = [
  "serde_core",
  "serde_json",
  "toml",
- "winnow",
+ "winnow 1.0.3",
  "yaml-rust2",
 ]
 
 [[package]]
 name = "console"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
  "windows-sys 0.61.2",
 ]
@@ -832,9 +832,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8599749b6667e2f0c910c1d0dff6901163ff698a52d5a39720f61b5be4b20d3"
 dependencies = [
  "futures-core",
- "prost 0.14.3",
+ "prost 0.14.4",
  "prost-types",
- "tonic 0.14.2",
+ "tonic 0.14.5",
  "tonic-prost",
  "tracing-core",
 ]
@@ -852,14 +852,14 @@ dependencies = [
  "hdrhistogram",
  "humantime",
  "hyper-util",
- "prost 0.14.3",
+ "prost 0.14.4",
  "prost-types",
  "serde",
  "serde_json",
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic 0.14.2",
+ "tonic 0.14.5",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -976,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -991,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d883447757bb0ee46f233e9dc22eb84d93a9508c9b868687b274fc431d886bf"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
  "alloca",
  "anes",
@@ -1016,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed943f81ea2faa8dcecbbfa50164acf95d555afec96a27871663b300e387b2e4"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools 0.13.0",
@@ -1136,7 +1136,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1170,7 +1170,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1184,7 +1184,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1195,7 +1195,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1206,14 +1206,28 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
@@ -1228,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -1244,7 +1258,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1265,7 +1279,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1275,7 +1289,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1296,7 +1310,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.114",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -1347,13 +1361,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1432,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
 ]
@@ -1484,7 +1498,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1504,7 +1518,7 @@ checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1515,9 +1529,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e8918065695684b2b0702da20382d5ae6065cf3327bc2d6436bd49a71ce9f3"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
 dependencies = [
  "serde",
  "serde_core",
@@ -1579,9 +1593,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -1601,15 +1615,15 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1618,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "flexi_logger"
-version = "0.31.8"
+version = "0.31.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aea7feddba9b4e83022270d49a58d4a1b3fdad04b34f78cf1ce471f698e42672"
+checksum = "2e90140a77c0ffbe2e4839e062983ec4ec60d4473e41a4fcce0884809d1b76d6"
 dependencies = [
  "chrono",
  "core_affinity",
@@ -1629,7 +1643,7 @@ dependencies = [
  "log",
  "nu-ansi-term",
  "regex",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1672,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "3.2.2"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf68cef89750956493a66a10f512b9e58d9db21f2a573c079c0bdf1207a54a7"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
 dependencies = [
  "autocfg",
  "tokio",
@@ -1694,9 +1708,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1709,9 +1723,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1719,15 +1733,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1747,38 +1761,44 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1788,7 +1808,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1835,9 +1854,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -1848,14 +1878,14 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "goat-lib"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "regex",
 ]
 
 [[package]]
 name = "goatns"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "argon2",
  "askama",
@@ -1883,12 +1913,14 @@ dependencies = [
  "gethostname",
  "goat-lib",
  "goatns-macros",
+ "governor",
  "hex",
  "hickory-resolver",
  "init-tracing-opentelemetry",
  "ipnet",
- "json5 1.3.0",
+ "json5 1.3.1",
  "log",
+ "nonzero_ext",
  "num-traits",
  "oauth2",
  "openidconnect",
@@ -1898,7 +1930,7 @@ dependencies = [
  "opentelemetry_sdk",
  "packed_struct",
  "pcap",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_core 0.9.5",
  "regex",
  "reqwest",
@@ -1913,9 +1945,9 @@ dependencies = [
  "sha2",
  "shellexpand",
  "sqlx",
- "syn 2.0.114",
+ "syn 2.0.118",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-cron-scheduler",
@@ -1939,7 +1971,30 @@ name = "goatns-macros"
 version = "0.0.2"
 dependencies = [
  "proc-macro2",
- "syn 2.0.114",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "governor"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.4",
+ "smallvec",
+ "spinning_top",
+ "web-time",
 ]
 
 [[package]]
@@ -1955,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1965,7 +2020,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2021,12 +2076,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -2082,9 +2152,9 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tracing",
@@ -2104,10 +2174,10 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "resolv-conf",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -2141,9 +2211,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2198,9 +2268,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2213,7 +2283,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2221,20 +2290,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -2252,14 +2320,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -2268,7 +2335,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2276,9 +2343,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2300,12 +2367,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -2313,9 +2381,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2326,9 +2394,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2340,15 +2408,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2360,15 +2428,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2398,9 +2466,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2419,12 +2487,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2437,7 +2505,7 @@ checksum = "c727f80bfa4a6c6e2508d2f05b6f4bfce242030bd88ed15ae5331c5b5d30fba7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2450,7 +2518,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -2458,33 +2526,24 @@ dependencies = [
 
 [[package]]
 name = "ipconfig"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.5.10",
+ "socket2",
  "widestring",
- "windows-sys 0.48.0",
- "winreg",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 dependencies = [
  "schemars 0.8.22",
- "serde",
-]
-
-[[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
  "serde",
 ]
 
@@ -2523,9 +2582,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -2539,11 +2598,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -2560,9 +2620,9 @@ dependencies = [
 
 [[package]]
 name = "json5"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c86c72f9e1d3fe29baa32cab8896548eef9aae271fce4e796d16b583fdf6d5"
+checksum = "733a844dbd6fef128e98cb4487b887cb55454d92cd9994b1bafe004fabbe670c"
 dependencies = [
  "serde",
  "ucd-trie",
@@ -2579,9 +2639,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -2595,19 +2655,20 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "libc",
- "redox_syscall 0.7.0",
+ "plain",
+ "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -2623,15 +2684,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -2651,15 +2712,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -2669,6 +2730,17 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "serde",
+ "winapi",
+]
 
 [[package]]
 name = "matchers"
@@ -2697,9 +2769,18 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -2735,9 +2816,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -2746,9 +2827,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.12"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dec6bd31b08944e08b58fd99373893a6c17054d6f3ea5006cc894f4f4eee2a"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -2762,6 +2843,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2770,6 +2870,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2801,7 +2907,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -2820,7 +2926,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2873,7 +2979,7 @@ dependencies = [
  "chrono",
  "getrandom 0.2.17",
  "http",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reqwest",
  "serde",
  "serde_json",
@@ -2885,9 +2991,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 dependencies = [
  "critical-section",
  "portable-atomic",
@@ -2922,7 +3028,7 @@ dependencies = [
  "oauth2",
  "p256",
  "p384",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde-value",
@@ -2938,9 +3044,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
@@ -2952,7 +3058,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -2982,7 +3088,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost 0.13.5",
  "reqwest",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tonic 0.13.1",
  "tracing",
@@ -3017,9 +3123,9 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
 ]
@@ -3079,7 +3185,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3217,9 +3323,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -3227,9 +3333,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f9dbced329c441fa79d80472764b1a2c7e57123553b8519b36663a2fb234ed"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3237,22 +3343,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb96d5051a78f44f43c8f712d8e810adb0ebf923fc9ed2655a7f66f63ba8ee5"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602113b5b5e8621770cfd490cfd90b9f84ab29bd2b0e49ad83eb6d186cef2365"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2",
@@ -3260,9 +3366,9 @@ dependencies = [
 
 [[package]]
 name = "pgvector"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc58e2d255979a31caa7cabfa7aac654af0354220719ab7a68520ae7a91e8c0b"
+checksum = "3673cba5b9a124916096a423b806a9f29620972c6c97b08db5f2053e9428b481"
 dependencies = [
  "serde",
 ]
@@ -3287,35 +3393,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs1"
@@ -3340,9 +3440,15 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -3374,15 +3480,15 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -3413,9 +3519,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
@@ -3439,14 +3545,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -3459,7 +3565,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
  "version_check",
  "yansi",
 ]
@@ -3476,12 +3582,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive 0.14.3",
+ "prost-derive 0.14.4",
 ]
 
 [[package]]
@@ -3494,29 +3600,29 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
- "prost 0.14.3",
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -3556,10 +3662,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.9"
+name = "quanta"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3568,8 +3689,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.1",
- "thiserror 2.0.17",
+ "socket2",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -3577,20 +3698,20 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3605,16 +3726,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -3626,6 +3747,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3633,9 +3760,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3644,9 +3771,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3691,10 +3818,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.11.0"
+name = "raw-cpuid"
+version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -3716,16 +3852,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
+checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3736,7 +3872,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3756,14 +3892,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3773,9 +3909,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3784,9 +3920,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rend"
@@ -3837,7 +3973,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -3920,11 +4056,11 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd490c5b18261893f14449cbd28cb9c0b637aebf161cd77900bfdedaff21ec32"
+checksum = "81116b9531d61eabc41aeb228e4b6b2435bcca3233b98cf3b3077d4e6e9debb3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "once_cell",
  "serde",
  "serde_derive",
@@ -3954,9 +4090,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "8.10.0"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f783a9e226b5319beefe29d45941f559ace8b56801bb8355be17eea277fc8272"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -3965,22 +4101,22 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.10.0"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "303d4e979140595f1d824b3dd53a32684835fa32425542056826521ac279f538"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
 dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.114",
+ "syn 2.0.118",
  "walkdir",
 ]
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.10.0"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6b4ab509cae251bd524d2425d746b0af0018f5a81fc1eaecdd4e661c8ab3a0"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
  "sha2",
  "walkdir",
@@ -3998,25 +4134,26 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.40.0"
+version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
 dependencies = [
  "arrayvec",
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -4029,11 +4166,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "errno 0.3.14",
  "libc",
  "linux-raw-sys",
@@ -4042,9 +4179,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4058,9 +4195,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -4070,9 +4207,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.2"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4080,9 +4217,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4098,9 +4235,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -4113,9 +4250,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -4127,7 +4264,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
- "schemars_derive",
  "serde",
  "serde_json",
 ]
@@ -4146,26 +4282,14 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -4184,14 +4308,14 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "sea-orm"
-version = "1.1.19"
+version = "1.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d945f62558fac19e5988680d2fdf747b734c2dbc6ce2cb81ba33ed8dde5b103"
+checksum = "2dc312fedd460a47ea563911761d254a84e7b51d8cc73ec92c929e78f33fa957"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4200,6 +4324,7 @@ dependencies = [
  "derive_more",
  "futures-util",
  "log",
+ "mac_address",
  "ouroboros",
  "pgvector",
  "rust_decimal",
@@ -4210,7 +4335,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "strum 0.26.3",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "url",
@@ -4219,9 +4344,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-cli"
-version = "1.1.19"
+version = "1.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94492e2ab6c045b4cc38013809ce255d14c3d352c9f0d11e6b920e2adc948ad"
+checksum = "da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450"
 dependencies = [
  "chrono",
  "clap",
@@ -4237,23 +4362,23 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-macros"
-version = "1.1.19"
+version = "1.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c2e64a50a9cc8339f10a27577e10062c7f995488e469f2c95762c5ee847832"
+checksum = "9b9a3f90e336ec74803e8eb98c61bc98754c1adfba3b4f84d946237b752b1c88"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.114",
+ "syn 2.0.118",
  "unicode-ident",
 ]
 
 [[package]]
 name = "sea-orm-migration"
-version = "1.1.19"
+version = "1.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7315c0cadb7e60fb17ee2bb282aa27d01911fc2a7e5836ec1d4ac37d19250bb4"
+checksum = "07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e"
 dependencies = [
  "async-trait",
  "clap",
@@ -4308,8 +4433,8 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
- "thiserror 2.0.17",
+ "syn 2.0.118",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4334,7 +4459,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4359,11 +4484,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4372,9 +4497,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4382,9 +4507,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -4445,25 +4570,14 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -4494,9 +4608,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -4515,17 +4629,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.0",
+ "schemars 1.2.1",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -4534,14 +4648,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4593,18 +4707,18 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shellexpand"
-version = "3.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
  "dirs",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -4628,9 +4742,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simdutf8"
@@ -4640,43 +4754,33 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4684,6 +4788,15 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
 dependencies = [
  "lock_api",
 ]
@@ -4736,8 +4849,8 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.15.5",
- "hashlink",
- "indexmap 2.13.0",
+ "hashlink 0.10.0",
+ "indexmap 2.14.0",
  "log",
  "memchr",
  "once_cell",
@@ -4748,7 +4861,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-stream",
@@ -4768,7 +4881,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4791,7 +4904,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.114",
+ "syn 2.0.118",
  "tokio",
  "url",
 ]
@@ -4805,7 +4918,7 @@ dependencies = [
  "atoi",
  "base64 0.22.1",
  "bigdecimal",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -4827,7 +4940,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "rust_decimal",
  "serde",
@@ -4836,7 +4949,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "uuid",
@@ -4852,7 +4965,7 @@ dependencies = [
  "atoi",
  "base64 0.22.1",
  "bigdecimal",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "byteorder",
  "chrono",
  "crc",
@@ -4871,7 +4984,7 @@ dependencies = [
  "memchr",
  "num-bigint",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -4879,7 +4992,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "uuid",
@@ -4906,7 +5019,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "url",
@@ -4966,7 +5079,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4988,9 +5101,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5014,7 +5127,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5031,12 +5144,12 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5053,11 +5166,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -5068,18 +5181,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5133,9 +5246,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -5153,9 +5266,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5168,9 +5281,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -5178,7 +5291,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -5202,13 +5315,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5251,45 +5364,45 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.11+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "serde_core",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5320,9 +5433,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "axum",
@@ -5337,7 +5450,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.1",
+ "socket2",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
@@ -5349,13 +5462,13 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
- "prost 0.14.3",
- "tonic 0.14.2",
+ "prost 0.14.4",
+ "tonic 0.14.5",
 ]
 
 [[package]]
@@ -5366,7 +5479,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -5395,12 +5508,12 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5409,7 +5522,6 @@ dependencies = [
  "http-body-util",
  "http-range-header",
  "httpdate",
- "iri-string",
  "mime",
  "mime_guess",
  "percent-encoding",
@@ -5420,6 +5532,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -5464,10 +5577,10 @@ dependencies = [
  "futures",
  "http",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tracing",
@@ -5519,7 +5632,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5585,9 +5698,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -5618,9 +5731,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -5642,9 +5755,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
@@ -5663,9 +5776,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -5712,11 +5825,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -5724,13 +5837,13 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
  "uuid",
 ]
 
@@ -5754,11 +5867,11 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -5809,9 +5922,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
@@ -5824,35 +5937,33 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.56"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5860,31 +5971,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.83"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5906,14 +6017,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.5"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5986,7 +6097,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5997,7 +6108,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6005,6 +6116,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"
@@ -6300,34 +6422,33 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
+name = "winnow"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
+ "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -6340,13 +6461,13 @@ dependencies = [
 
 [[package]]
 name = "yaml-rust2"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
+checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
 dependencies = [
  "arraydeque",
  "encoding_rs",
- "hashlink",
+ "hashlink 0.11.1",
 ]
 
 [[package]]
@@ -6357,9 +6478,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6368,68 +6489,68 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.33"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.33"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -6438,9 +6559,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6449,13 +6570,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6467,22 +6588,22 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "memchr",
  "zopfli",
 ]
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.5"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zmij"
-version = "1.0.14"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ default = []
 [workspace]
 members = [".", "goat-lib", "goatns-macros"]
 [workspace.package]
-version = "0.7.0"
+version = "0.9.0"
 categories = ["network-programming"]
 edition = "2024"
 license = "MIT"
-rust-version = "1.87"
+rust-version = "1.95"
 repository = "https://github.com/yaleman/goatns.git"
 
 
@@ -57,9 +57,11 @@ concread = "0.5.8"
 config = { version = "0.15", features = ["json"] }
 dialoguer = "0.12.0"
 enum-iterator = "2.3.0"
-flexi_logger = { version = "0.31", features = ["async", "default"] }
-futures = "0.3.31"
-futures-util = "0.3.31"
+flexi_logger = { version = "^0.31", features = ["async", "default"] }
+futures = "0.3.32"
+futures-util = "0.3.32"
+governor = { version = "0.8", features = ["std", "quanta"] }
+nonzero_ext = "0.3"
 gethostname = "1.1.0"
 goat-lib = { path = "goat-lib" }
 goatns-macros = { path = "./goatns-macros" }

--- a/docs/src/dnssec.md
+++ b/docs/src/dnssec.md
@@ -1,0 +1,126 @@
+# DNSSEC Support
+
+GoatNS supports serving DNSSEC-signed zones. This is an authoritative-only server — it does not perform DNSSEC validation (that is a recursive resolver concern). The deployment model is **offline signing**: zones are signed by a companion tool before being loaded into the server.
+
+## Overview
+
+DNSSEC (Domain Name System Security Extensions) provides authentication and integrity for DNS data using public-key cryptography. When a zone is signed:
+
+1. Each RRset (group of records with the same name and type) gets an RRSIG (signature) record
+2. A chain of NSEC or NSEC3 records provides authenticated denial of existence
+3. DNSKEY records publish the public keys used for verification
+4. DS records in the parent zone establish the chain of trust
+
+## Supported Record Types
+
+| Type | Code | RFC | Purpose |
+|------|------|-----|---------|
+| DNSKEY | 48 | RFC 4034 | Public key used in DNSSEC |
+| RRSIG | 46 | RFC 4034 | Signature for an RRset |
+| NSEC | 47 | RFC 4034 | Next Secure record (authenticated denial) |
+| NSEC3 | 50 | RFC 5155 | Next Secure v3 (hashed denial) |
+| NSEC3PARAM | 51 | RFC 5155 | NSEC3 parameters for the zone |
+| DS | 43 | RFC 4034 | Delegation Signer (parent zone) |
+| CDNSKEY | 60 | RFC 7344 | Child DNSKEY (for CDS) |
+| CDS | 59 | RFC 7344 | Child DS (for parent zone updates) |
+
+## Zone Signing Workflow
+
+### 1. Generate Keys
+
+Generate a Key Signing Key (KSK) and Zone Signing Key (ZSK):
+
+```bash
+goatns sign-zone generate-keys --zone example.com --output-dir /path/to/keys/
+```
+
+This creates:
+- `example.com.ksk.pem` — KSK private key
+- `example.com.zsk.pem` — ZSK private key
+
+### 2. Sign the Zone
+
+```bash
+goatns sign-zone sign \
+  --zone example.com \
+  --ksk /path/to/keys/example.com.ksk.pem \
+  --zsk /path/to/keys/example.com.zsk.pem \
+  --input-zone zones.json \
+  --output-zone signed_zones.json
+```
+
+This adds DNSKEY, RRSIG, NSEC/NSEC3, and DS records to the zone.
+
+### 3. Import the Signed Zone
+
+```bash
+goatns import-zones --file signed_zones.json
+```
+
+The zone's `signed` flag will be set to `true` automatically when DNSKEY records are present.
+
+### 4. Publish DS Records
+
+Upload the DS records to your registrar or parent zone operator. This establishes the chain of trust.
+
+## Server Behavior
+
+### AD Bit
+
+The `ad` (Authentic Data) bit in the response header is set to `true` when:
+- The zone has `signed: true` in the database
+- The response contains valid RRSIG records
+
+### DO Bit
+
+When a client sets the DO (DNSSEC OK) bit in an OPT pseudo-RR:
+- RRSIG records matching the queried type are included in the answer section
+- The response includes an OPT RR in the additional section
+
+### EDNS0/OPT
+
+The server supports EDNS0 (RFC 6891):
+- Parses the OPT pseudo-RR from the query's additional section
+- Includes an OPT RR in the response when the query had one
+- UDP payload size is set to 1232 bytes (modern minimum)
+
+### TCP Fallback
+
+Per RFC 7766:
+- If a UDP response exceeds the UDP buffer size, the TC (Truncated) bit is set
+- The client should retry over TCP to get the full response
+- TCP responses are not truncated
+
+## Configuration
+
+DNSSEC is configured per-zone via the `signed` flag:
+
+```json
+{
+  "name": "example.com",
+  "rname": "admin@example.com",
+  "serial": 2024010101,
+  "refresh": 3600,
+  "retry": 600,
+  "expire": 604800,
+  "minimum": 86400,
+  "signed": true
+}
+```
+
+## Key Rotation
+
+Key rotation is performed offline:
+
+1. Generate new key(s)
+2. Sign the zone with both old and new keys during the rollover period
+3. Wait for the old signatures to expire from caches
+4. Remove the old key and re-sign with only the new key
+5. Update DS records in the parent zone if the KSK changed
+
+## Security Considerations
+
+- Private keys are never stored on the running server
+- The server does not perform cryptographic operations during query handling
+- Zone signing is done offline, keeping keys away from the network
+- The `signed` flag must be explicitly set by the operator after verifying signatures

--- a/docs/src/rrtypes.md
+++ b/docs/src/rrtypes.md
@@ -10,8 +10,8 @@
   - [ ] should check for zones, is currently just YOLOing a response to any request
   - [x] return a HINFO record of "RFC8482", can't be stored
 - [x] CAA (257) RFC6844
-- [ ] CDNSKEY (60) RFC7344 Child copy of DNSKEY record, for transfer to parent
-- [ ] CDNSKEY (59) RFC7344 Child copy of DS record, for transfer to parent
+- [x] CDNSKEY (60) RFC7344 Child copy of DNSKEY record, for transfer to parent
+- [x] CDS (59) RFC7344 Child copy of DS record, for transfer to parent
 - [ ] CERT (37) RFC4398 Certificate record
 - [ ] CSYNC (62) RFC7477 Specify a synchronization mechanism between a child and a parent DNS zone.
       Typical example is declaring the same NS records in the parent and the child zone
@@ -19,7 +19,8 @@
 - [ ] DHCID (49) RFC4701 Used in conjunction with the FQDN option to DHCP
 - [ ] DLV (32769) RFC4431 DNSSEC Lookaside Validation record
 - [ ] DNAME (39) RFC6672 Delegation name record
-- [ ] DNSKEY (48) RFC4034 DNS Key record The key record used in DNSSEC.
+- [x] DS (43) RFC4034 Delegation Signer record, part of DNSSEC
+- [x] DNSKEY (48) RFC4034 DNS Key record The key record used in DNSSEC.
 - [ ] EUI48 (108) RFC7043 MAC address (EUI-48) A 48-bit IEEE Extended Unique Identifier.
 - [ ] EUI64 (109) RFC7043 MAC address (EUI-64) A 64-bit IEEE Extended Unique Identifier.
 - [x] HINFO (13) RFC8482 Providing Minimal-Sized Responses to DNS Queries That Have QTYPE=ANY
@@ -41,17 +42,17 @@
 - [ ] NAPTR (35) RFC3403 Naming Authority Pointer Allows regular-expression-based rewriting of
       domain names which can then be used as URIs, further domain names to lookups, etc.
 - [x] NS
-- [ ] NSEC (47) RFC4034 Next Secure record Part of DNSSEC—used to prove a name does not exist. Uses
+- [x] NSEC (47) RFC4034 Next Secure record Part of DNSSEC—used to prove a name does not exist. Uses
       the same format as the (obsolete) NXT record.
-- [ ] NSEC3 50 RFC5155 Next Secure record version 3 An extension to DNSSEC that allows proof of
+- [x] NSEC3 50 RFC5155 Next Secure record version 3 An extension to DNSSEC that allows proof of
       nonexistence for a name without permitting zonewalking
-- [ ] NSEC3PARAM 51 RFC5155 NSEC3 parameters Parameter record for use with NSEC3
+- [x] NSEC3PARAM 51 RFC5155 NSEC3 parameters Parameter record for use with NSEC3
 - [ ] OPENPGPKEY 61 RFC7929 OpenPGP public key record A DNS-based Authentication of Named Entities
       (DANE) method for publishing and locating OpenPGP public keys in DNS for a specific email
       address using an OPENPGPKEY DNS resource record.
-- [ ] OPT 41 RFC6891 Option This is a pseudo-record type needed to support EDNS.
+- [x] OPT 41 RFC6891 Option This is a pseudo-record type needed to support EDNS.
 - [x] PTR 12 RFC1035
-- [ ] RRSIG 46 RFC4034 DNSSEC signature Signature for a DNSSEC-secured record set. Uses the same
+- [x] RRSIG 46 RFC4034 DNSSEC signature Signature for a DNSSEC-secured record set. Uses the same
       format as the SIG record.
 - [ ] RP 17 RFC1183 Responsible Person Information about the responsible person(s) for the domain.
       Usually an email address with the @ replaced by a .

--- a/docs/src/security_audit_2026-06-26.md
+++ b/docs/src/security_audit_2026-06-26.md
@@ -1,0 +1,647 @@
+# Security Audit Report
+
+**Date**: 2026-06-26
+**Scope**: Rust source code in `src/`, `goatns-macros/`, `goat-lib/`
+**Auditor**: Automated comprehensive review
+
+---
+
+## Executive Summary
+
+The GoatNS DNS server is built in memory-safe Rust with `#![forbid(unsafe_code)]`, eliminating entire classes of memory safety vulnerabilities. The project uses well-vetted crates (Argon2id, sea-orm, axum, rustls). However, this audit identified **7 High**, **12 Medium**, and **8 Low** severity logic-level security issues across authentication, authorization, session management, and input validation.
+
+---
+
+## CRITICAL
+
+No critical findings identified.
+
+---
+
+## HIGH Severity
+
+---
+
+### H-1: Missing Admin Authorization Check on Admin Endpoints
+
+**Location**: `src/web/ui/admin_ui.rs:48-58`, `src/web/ui/admin_ui.rs:60-102`, `src/web/ui/admin_ui.rs:118-197`
+
+**Category**: Authorization Bypass
+
+**Problem**: The admin UI routes (`/ui/admin`, `/ui/admin/reports/unowned_records`, `/ui/admin/zones/assign_ownership/{id}`) only call `check_logged_in()` which verifies the user is authenticated and not disabled, but **never checks `user.admin`**. Any authenticated user can access the admin dashboard, view all zones (including unowned ones), and assign zone ownership.
+
+**Vulnerable Code**:
+
+```rust
+// src/web/ui/admin_ui.rs:48-58
+pub(crate) async fn dashboard(mut session: Session) -> Result<AdminUITemplate, Redirect> {
+    let user = check_logged_in(&mut session, url).await?;
+    // No check: if !user.admin { return Err(...) }
+    Ok(AdminUITemplate {
+        user_is_admin: user.admin,  // Only used for display, not access control
+    })
+}
+```
+
+**Reproduction**:
+
+1. Create a regular (non-admin) user account via the web UI.
+2. Log in as that regular user.
+3. Navigate directly to `/ui/admin` in the browser.
+4. The full admin dashboard loads, showing all zones and administrative controls.
+5. Navigate to `/ui/admin/zones/assign_ownership/{id}` to reassign any zone to any user.
+
+**Impact**: Complete admin panel compromise. Any authenticated user can view all zones, modify zone ownership, and effectively take full control of the DNS server's authoritative zones.
+
+**Fix**: Add an admin check in each admin route handler:
+
+```rust
+if !user.admin {
+    return Err(Urls::Home.redirect());
+}
+```
+
+---
+
+### H-2: Open Redirect via Session-Stored Redirect Path
+
+**Location**: `src/web/auth/mod.rs:359-361`, `src/web/auth/mod.rs:425-427`, `src/web/auth/mod.rs:541-543`, `src/web/ui/mod.rs:260-281`
+
+**Category**: Open Redirect / Phishing
+
+**Problem**: After login/signup, the server reads a redirect path from the session (`session.remove("redirect")`) and issues a `Redirect::to(&destination)` without any validation. An attacker can store an arbitrary URL in the session via the `redirect` query parameter and use it to redirect victims to malicious sites after OAuth callback completion.
+
+**Vulnerable Code**:
+
+```rust
+// src/web/auth/mod.rs:424-428
+let redirect: Option<String> = session.remove("redirect").await.unwrap_or(None);
+match redirect {
+    Some(destination) => Ok(Redirect::to(&destination).into_response()),
+    None => Ok(Urls::ZonesList.redirect().into_response()),
+}
+```
+
+The redirect path is stored in `src/web/ui/mod.rs:281`:
+
+```rust
+session.insert(SESSION_REDIRECT_KEY, redirect_path).await
+```
+
+where `redirect_path` comes from the request URI path — which can be manipulated.
+
+**Reproduction**:
+
+1. Attacker crafts a login URL with a redirect parameter pointing to `https://evil.com/phishing`.
+2. Victim clicks the link and is taken to the OAuth login flow.
+3. After completing OAuth login, the server redirects the victim to `https://evil.com/phishing`.
+4. The attacker's site can mimic the GoatNS UI to harvest credentials or steal session tokens.
+
+**Impact**: Phishing attacks, credential theft, token theft via redirection to attacker-controlled origins.
+
+**Fix**: Validate the redirect destination against an allowlist (same-origin check or known safe paths) before issuing the redirect. Reject absolute URLs that point to external hosts.
+
+---
+
+### H-3: Zone Name Not Validated Against TLD Allowlist on UI Creation
+
+**Location**: `src/web/ui/zones.rs:23-132`
+
+**Category**: Input Validation / Authorization Bypass
+
+**Problem**: The web UI zone creation endpoint (`POST /ui/zones/new`) validates the zone name using `dns_name()` but does **not** call `check_valid_tld()`. The API endpoint (`POST /api/zone`) does call `check_valid_tld()`. This inconsistency allows users to create zones with arbitrary TLDs through the web UI, bypassing the TLD restriction.
+
+**Vulnerable Code**:
+
+```rust
+// src/web/ui/zones.rs:40-46 — missing check_valid_tld
+if !dns_name(&form.name) {
+    return Err(Urls::Home.redirect_with_query(HashMap::from([(
+        "error".to_string(),
+        "Invalid DNS name".to_string(),
+    )])));
+}
+// No TLD check here!
+```
+
+**Reproduction**:
+
+1. Log in as any authenticated user.
+2. Navigate to the zone creation page (`/ui/zones/new`).
+3. Submit a zone with a name like `attacker.local` or `evil.com`.
+4. The zone is created successfully despite not being in the allowed TLD list.
+5. The server now authoritatively responds for that zone, potentially hijacking DNS resolution.
+
+**Impact**: DNS hijacking. An attacker can create zones for domains the server shouldn't be authoritative for, intercepting or manipulating DNS queries for those domains.
+
+**Fix**: Add `check_valid_tld(&form.name, &state.read().await.config.allowed_tlds)` check before zone creation in the UI handler, matching the API endpoint behavior.
+
+---
+
+### H-4: DoH GET Endpoint Leaks Internal Records Without Authentication
+
+**Location**: `src/web/doh/mod.rs:179-348`
+
+**Category**: Information Disclosure
+
+**Problem**: The DoH GET endpoint (`GET /dns-query`) queries the database directly and returns DNS records without any authentication or authorization check. While this is standard for public DNS-over-HTTPS resolvers, the endpoint also exposes records from the internal `records_merged` table which may include private/internal zone data. The `name` parameter is used directly in a database query without rate limiting, enabling enumeration of all records.
+
+**Vulnerable Code**:
+
+```rust
+// src/web/doh/mod.rs:228-235
+let records = match entities::records_merged::Entity::find()
+    .filter(
+        entities::records_merged::Column::Name.eq(qname.clone())
+            .and(entities::records_merged::Column::Rrtype.eq(rr_type_value as u16)),
+    )
+    .all(&read_txn)
+    .await
+```
+
+**Reproduction**:
+
+1. Send a DoH query for any domain: `GET /dns-query?name=example.com&type=A`
+2. Iterate through record types (A, AAAA, MX, TXT, etc.) to enumerate all records for a zone.
+3. Query for internal/private zone names (e.g., `internal.corp`, `admin.local`) to extract sensitive internal DNS data.
+4. No authentication is required — the endpoint is fully public.
+
+**Impact**: Complete enumeration of all DNS records hosted on the server, including internal/private infrastructure that may leak hostnames, IP addresses, and service information useful for further attacks.
+
+**Fix**: If this server is meant to be a public resolver, document this behavior explicitly. If it's meant to be private, add authentication to the DoH endpoint or restrict it to localhost/trusted IPs.
+
+---
+
+### H-5: No Rate Limiting on DNS and API Endpoints
+
+**Location**: `src/servers.rs:118-182` (UDP), `src/servers.rs:347-388` (TCP), `src/web/mod.rs:175-241` (API)
+
+**Category**: Denial of Service
+
+**Problem**: There is no rate limiting anywhere in the application — not on DNS queries, API endpoints, or authentication attempts. The only concurrency control is `MAX_IN_FLIGHT = 512` for the datastore channel, which limits concurrent database operations but doesn't prevent abuse.
+
+**Reproduction**:
+
+- **DNS Amplification**: Send spoofed DNS queries (with source IP set to victim's IP) to the server. The server responds to the victim with potentially large DNS responses, amplifying DDoS traffic.
+- **Brute Force**: Send unlimited login attempts to `POST /api/login` to brute-force API tokens.
+- **DoS**: Flood the DNS listener with queries. Once the 512-slot channel is full, legitimate queries are dropped.
+
+**Impact**: DNS amplification attacks, brute-force credential attacks, and denial of service for legitimate users.
+
+**Fix**: Implement rate limiting using `tower::limit::RateLimit` or `axum::extract` with per-IP tracking. For DNS, implement Response Rate Limiting (RRL) per BCP38 recommendations.
+
+---
+
+### H-6: Session Cookie Missing `SameSite` and `HttpOnly` Attributes
+
+**Location**: `src/web/auth/mod.rs:456-480`
+
+**Category**: Session Management / CSRF
+
+**Problem**: The session cookie is configured with `.with_secure(true)` and `.with_domain(...)` but is missing `SameSite` and `HttpOnly` attributes. Without `SameSite`, the cookie is sent on cross-site requests, enabling CSRF attacks. Without `HttpOnly`, JavaScript running in the browser can steal the session cookie.
+
+**Vulnerable Code**:
+
+```rust
+Ok(SessionManagerLayer::new(session_store)
+    .with_expiry(Expiry::OnInactivity(Duration::minutes(5)))
+    .with_name(COOKIE_NAME)
+    .with_secure(true)
+    .with_domain(config.hostname.clone()))
+// Missing: .with_same_site(...) and .with_http_only(true)
+```
+
+**Reproduction**:
+
+1. **CSRF Attack**: Attacker creates a malicious website that makes requests to the GoatNS server. When a victim visits the site, their browser includes the session cookie, allowing the attacker to perform actions as the authenticated user.
+2. **XSS + Session Theft**: If any XSS vulnerability exists (e.g., via template injection), JavaScript can read `document.cookie` and exfiltrate the session token because `HttpOnly` is not set.
+
+**Impact**: Cross-site request forgery, session hijacking via XSS.
+
+**Fix**: Add `.with_same_site(tower_sessions::cookie::SameSite::Strict)` and `.with_http_only(true)` to the session configuration.
+
+---
+
+### H-7: OAuth State Parameter Not Validated Against Session
+
+**Location**: `src/web/auth/mod.rs:292-298`
+
+**Category**: Authentication Flaw / CSRF
+
+**Problem**: The `state` parameter from the OAuth callback is passed directly to `pop_verifier()` without checking that it was actually generated by this server instance. The `redirect` query parameter in `QueryForLogin` is not validated, enabling the open redirect described in H-2.
+
+**Vulnerable Code**:
+
+```rust
+// src/web/auth/mod.rs:292-298
+let verifier = state.pop_verifier(query_state.clone()).await;
+let (pkce_verifier_secret, nonce) = match verifier {
+    Some((p, n)) => (p, n),
+    None => {
+        error!("Couldn't find a session, redirecting...");
+        return Err(Urls::Login.redirect().into_response());
+    }
+};
+```
+
+The `QueryForLogin` struct has an unvalidated `redirect` field:
+
+```rust
+pub struct QueryForLogin {
+    pub state: Option<String>,
+    pub code: Option<String>,
+    pub redirect: Option<String>,  // Not validated
+}
+```
+
+**Reproduction**: Combined with H-2, an attacker can craft a login URL with a malicious redirect, trick a victim into authenticating, and then redirect them to an attacker-controlled site with the OAuth authorization code.
+
+**Impact**: OAuth flow hijacking, phishing, token theft.
+
+**Fix**: Validate the redirect URL against an allowlist before storing it in the session. Ensure the state parameter is cryptographically tied to the session.
+
+---
+
+## MEDIUM SeverITY
+
+---
+
+### M-1: DNSSEC Support Added — AD Bit Now Controlled by Zone Configuration
+
+**Location**: `src/servers.rs:571`, `src/datastore.rs:195`, `src/db/entities/zones.rs`
+
+**Category**: DNS Security
+
+**Previous Problem**: The server set `ad: false` and `cd: false` in all responses with TODO comments indicating DNSSEC was not implemented.
+
+**Current Status**: **Resolved.** DNSSEC support has been added:
+
+- New DNSSEC record types supported: DNSKEY, RRSIG, NSEC, NSEC3, NSEC3PARAM, DS, CDNSKEY, CDS
+- Zones have a `signed` boolean column that controls the `ad` bit in responses
+- EDNS0/OPT pseudo-RR parsing implemented (RFC 6891)
+- DO (DNSSEC OK) bit is read from queries and used to include RRSIG records in responses
+- CD (Checking Disabled) bit is copied from query to response
+- TCP fallback per RFC 7766: truncated UDP responses set the TC bit, clients retry over TCP
+- RRSIG records are automatically included when the DO bit is set and the zone is signed
+
+**Residual Risk**: This is an authoritative-only server. DNSSEC validation (recursive resolver concern) is not implemented and is out of scope. Zone signing is done offline — the `sign-zone` subcommand (planned) will generate keys and sign zones before loading them into the database. Key management is the operator's responsibility.
+
+---
+
+### M-2: TCP Connection Length Field Not Properly Validated
+
+**Location**: `src/servers.rs:194-207`
+
+**Category**: Input Validation / DoS
+
+**Problem**: The TCP DNS message length field is read as a `u16` but there's no minimum length validation. A `msg_length` of 0 is technically valid per the code logic. There's no maximum length enforcement on TCP messages, allowing an attacker to claim a very large message length and cause the server to read indefinitely.
+
+**Vulnerable Code**:
+
+```rust
+let msg_length: usize = reader.read_u16().await?.into();
+// No validation: msg_length could be 0 or 65535
+let mut buf: Vec<u8> = vec![];
+while buf.len() < msg_length {
+    let len = match reader.read_buf(&mut buf).await { ... }
+```
+
+**Reproduction**: Open a TCP connection to the DNS server and send a length header claiming 65535 bytes but never send the data. The connection is tied up indefinitely (slowloris-style DoS).
+
+**Fix**: Enforce minimum (12 bytes for DNS header) and maximum (65535 bytes per RFC) message lengths. Add a read timeout for the message body.
+
+---
+
+### M-3: Zone File Import Allows Arbitrary File Reads via CLI
+
+**Location**: `src/cli.rs:148-175`, `src/datastore.rs:294-326`
+
+**Category**: Path Traversal
+
+**Problem**: The `import_zones` CLI command takes a `filename` parameter directly from the CLI argument and passes it to `load_zones()` which opens the file. There's no validation that the path is within an expected directory.
+
+**Reproduction**: Run `goatns import_zones /etc/passwd` — while this would fail JSON parsing, error messages may leak file contents or metadata.
+
+**Fix**: Validate that the import path is within an expected directory. Restrict zone file imports to a configured safe path.
+
+---
+
+### M-4: API Token Secret Logged in Plaintext
+
+**Location**: `src/web/api/auth.rs:48-50`
+
+**Category**: Information Leakage
+
+**Problem**: In test mode, the API login payload (which contains `token_secret`) is printed to stdout. The `debug!` log at line 50 could capture token secrets if log level is set to debug.
+
+**Vulnerable Code**:
+
+```rust
+#[cfg(test)]
+println!("Got login payload: {payload:?}");
+```
+
+**Reproduction**: Enable debug logging and observe log output. Token secrets will appear in plaintext.
+
+**Fix**: Never log sensitive payloads. Redact or mask `token_secret` before logging.
+
+---
+
+### M-5: Session Cookie Domain Set to Hostname — Cookie Tossing
+
+**Location**: `src/web/auth/mod.rs:479`
+
+**Category**: Session Management
+
+**Problem**: The session cookie domain is set to `config.hostname` which defaults to the system hostname. If the hostname is a bare name like `goatns`, the cookie will be sent to all subdomains (`*.goatns`).
+
+**Vulnerable Code**:
+
+```rust
+.with_domain(config.hostname.clone())
+```
+
+**Fix**: Make the cookie domain configurable and default to no domain restriction (host-only cookie). Document the security implications.
+
+---
+
+### M-6: No CORS Configuration on API Endpoints
+
+**Location**: `src/web/mod.rs:175-241`
+
+**Category**: Missing Security Controls
+
+**Problem**: The API server has no CORS (Cross-Origin Resource Sharing) configuration. Any website can make cross-origin requests to the API. Combined with the missing `HttpOnly` cookie attribute (H-6), this enables cross-site attacks.
+
+**Fix**: Add a CORS layer with restrictive origins. Use `tower_http::cors::CorsLayer` with explicit origin allowlist.
+
+---
+
+### M-7: `api_cookie_secret` Logged in Debug Output
+
+**Location**: `src/config.rs:338-341`
+
+**Category**: Information Leakage
+
+**Problem**: The `Display` implementation for `ConfigFile` includes extensive configuration details. While it correctly excludes `api_cookie_secret` via `#[serde(skip_serializing)]`, other sensitive fields could leak if the config is logged at debug level.
+
+**Fix**: Ensure the `Display` impl never exposes secrets. Audit all `Debug` and `Display` implementations for sensitive data exposure.
+
+---
+
+### M-8: Unbounded Zone File Parsing — Memory Exhaustion
+
+**Location**: `src/zones.rs:217-241`
+
+**Category**: Denial of Service
+
+**Problem**: The `load_zones` function reads the entire file into a string, then parses it as JSON. There's no size limit on the file.
+
+**Vulnerable Code**:
+
+```rust
+let mut buf: String = String::new();
+file.read_to_string(&mut buf)...;  // No size limit
+let jsonblob: Vec<serde_json::Value> = json5::from_str(&buf)...;  // Parses entire file
+```
+
+**Reproduction**: Create a multi-gigabyte JSON zone file and trigger an import. The server reads the entire file into memory, causing OOM.
+
+**Fix**: Add a maximum file size check before reading. Use streaming JSON parsing for large files.
+
+---
+
+### M-9: `export_zone_file` Allows Writing to Arbitrary Paths
+
+**Location**: `src/cli.rs:101-145`
+
+**Category**: Path Traversal
+
+**Problem**: The `export_zone_file` function takes an `output_filename` parameter and writes to it directly via `tokio::fs::File::create(filename)`. There's no path validation, allowing overwriting of arbitrary files.
+
+**Reproduction**: Run `goatns export_zone_file --output /etc/cron.d/backdoor` to overwrite critical system files.
+
+**Fix**: Validate the output path is within an expected directory (e.g., current working directory or configured export path).
+
+---
+
+### M-10: DoH GET Response Uses User-Controlled Data in Cache-Control
+
+**Location**: `src/web/doh/mod.rs:290`, `src/web/doh/mod.rs:335`, `src/web/doh/mod.rs:409`
+
+**Category**: Cache Poisoning
+
+**Problem**: The `Cache-Control: max-age={min_ttl}` header uses TTL values directly from database records. An attacker who can control record TTLs (via zone creation) can set arbitrary cache durations, potentially poisoning downstream caches.
+
+**Fix**: Clamp TTL values to a reasonable range (e.g., 1-86400 seconds) before using them in cache headers.
+
+---
+
+### M-11: Missing `HttpOnly` on Session Cookie
+
+**Location**: `src/web/auth/mod.rs:474-479`
+
+**Category**: Session Management
+
+**Problem**: Separate from the SameSite issue (H-6), the missing `HttpOnly` flag means that if any XSS vulnerability exists, the session cookie can be exfiltrated via JavaScript.
+
+**Fix**: Add `.with_http_only(true)` to the session manager layer configuration.
+
+---
+
+### M-12: Admin Can Assign Zone Ownership Without CSRF Protection (GET)
+
+**Location**: `src/web/ui/admin_ui.rs:204-206`
+
+**Category**: CSRF
+
+**Problem**: The `assign_zone_ownership` handler processes state-changing operations on both GET and POST. The GET handler doesn't validate a CSRF token.
+
+**Vulnerable Code**:
+
+```rust
+.route(
+    "/zones/assign_ownership/{id}",
+    get(assign_zone_ownership).post(assign_zone_ownership),
+)
+```
+
+**Reproduction**: An attacker tricks an admin into visiting a page that auto-submits a form to this endpoint, reassigning zone ownership without the admin's knowledge.
+
+**Fix**: Require POST for state-changing operations and validate CSRF tokens on all POST handlers.
+
+---
+
+## LOW SeverITY
+
+---
+
+### L-1: Information Leakage via Error Messages in Auth Flow
+
+**Location**: `src/web/auth/mod.rs:357-364`
+
+**Category**: Information Leakage
+
+**Problem**: When a database error occurs during login, the error handling pattern could leak information through timing differences or redirect behavior.
+
+**Fix**: Ensure error handling is uniform regardless of the failure reason. Use constant-time comparisons where applicable.
+
+---
+
+### L-2: `dns_name` Validator Rejects Valid Single-Label Names
+
+**Location**: `goat-lib/src/validators.rs:12-34`
+
+**Category**: Functional / Security-Adjacent
+
+**Problem**: The `dns_name` function rejects names without dots, preventing creation of single-label zones (e.g., `localhost`, `internal`) which are valid in some contexts.
+
+**Vulnerable Code**:
+
+```rust
+if !name.contains('.') {
+    return false;
+}
+```
+
+**Fix**: Allow single-label names when appropriate for internal/private use cases.
+
+---
+
+### L-3: Unused `ImportFile` Resp Channel — Potential Deadlock
+
+**Location**: `src/cli.rs:153-174`
+
+**Category**: DoS / Reliability
+
+**Problem**: The `import_zones` function creates a oneshot channel but the receiver is declared as `mut rx_oneshot` and never used properly. The loop checks `try_recv()` but the channel sender in the datastore may not fire correctly in all error cases, potentially causing the loop to spin indefinitely.
+
+**Fix**: Use proper async waiting on the oneshot channel with a timeout.
+
+---
+
+### L-4: `packet_dumper` Creates Files with Predictable Names
+
+**Location**: `src/packet_dumper.rs:34-41`
+
+**Category**: Information Leakage
+
+**Problem**: Packet capture files use a timestamp-based name without randomness. If two packets arrive in the same second, the second write overwrites the first.
+
+**Vulnerable Code**:
+
+```rust
+let filename = format!(
+    "{}/{}-{}.cap",
+    dest_dir.map(|f| f.display().to_string()).unwrap_or_else(|| "./captures".to_string()),
+    dump_type,
+    now.format("%Y-%m-%dT%H%M%SZ")
+);
+```
+
+**Fix**: Add a random component or counter to the filename.
+
+---
+
+### L-5: `println!` Statements in Production Code
+
+**Location**: `src/web/api/auth.rs:109`, `src/web/api/zones.rs:231,248,274`
+
+**Category**: Information Leakage
+
+**Problem**: Multiple `println!` statements exist in production (non-test) code paths. These can leak information to stdout in containerized environments.
+
+**Fix**: Replace with `info!` or `debug!` tracing macros.
+
+---
+
+### L-6: LOC Record Parsing Silently Defaults on Errors
+
+**Location**: `src/resourcerecord.rs:1305-1380`
+
+**Category**: Input Validation
+
+**Problem**: The LOC record parser uses `error!` logs and defaults to 0 or default values when parsing fails. This could lead to serving incorrect LOC data without any indication of a problem.
+
+**Fix**: Return an error for invalid LOC records instead of silently defaulting.
+
+---
+
+### L-7: No Maximum Limit on `GetZoneNames` Pagination
+
+**Location**: `src/datastore.rs:351-387`
+
+**Category**: DoS
+
+**Problem**: The `handle_get_zone_names` function accepts `offset` and `limit` parameters without enforcing a maximum limit. The web UI hardcodes `limit = 20`, but if these parameters come from user input in the future, an attacker could request all zones at once.
+
+**Fix**: Enforce a maximum limit (e.g., 100) in the database query function.
+
+---
+
+### L-8: `ContactDetails::to_html_parts` Outputs Unescaped URLs
+
+**Location**: `src/enums.rs:411-425`
+
+**Category**: XSS
+
+**Problem**: The `to_html_parts` method returns URLs that are directly interpolated into HTML templates. If `server` or `contact` contain malicious characters, this could enable stored XSS.
+
+**Vulnerable Code**:
+
+```rust
+ContactDetails::Mastodon { server, contact } => {
+    (contact.to_owned(), format!("https://{server}/@{contact}"))
+}
+```
+
+**Reproduction**: An admin sets their contact details with a malicious server value like `evil.com"><script>alert(1)</script>`. When other users view pages displaying admin contact info, the injected HTML/JS executes.
+
+**Fix**: Ensure Askama templates escape these values (Askama auto-escapes by default, but verify the template uses `{{ }}` rather than `{{{ }}}`).
+
+---
+
+## Positive Security Observations
+
+1. **Memory safety**: `#![forbid(unsafe_code)]` in `src/lib.rs` eliminates entire classes of memory safety vulnerabilities.
+2. **Strong password hashing**: API tokens use Argon2id (industry-standard memory-hard hashing).
+3. **PKCE in OAuth flow**: The OAuth2 implementation uses PKCE, preventing authorization code interception attacks.
+4. **CSRF tokens for API token management**: The user settings API token creation flow properly implements CSRF protection.
+5. **TLS by default**: The API server uses rustls with AWS-LC-RS crypto provider.
+6. **Clippy lints enabled**: Strict clippy settings (`#![deny(clippy::all)]`) catch many common issues.
+7. **Session expiry**: Sessions expire after 5 minutes of inactivity.
+8. **No SQL injection**: All database queries use parameterized queries via sea-orm.
+
+---
+
+## Summary Table
+
+| ID  | Severity | Category                | Location                           |
+|-----|----------|-------------------------|----------------------------------- |
+| H-1 | High     | AuthZ Bypass            | `src/web/ui/admin_ui.rs`           |
+| H-2 | High     | Open Redirect           | `src/web/auth/mod.rs`              |
+| H-3 | High     | Input Validation        | `src/web/ui/zones.rs`              |
+| H-4 | High     | Information Disclosure  | `src/web/doh/mod.rs`               |
+| H-5 | High     | DoS                     | `src/servers.rs`, `src/web/mod.rs` |
+| H-6 | High     | Session Management      | `src/web/auth/mod.rs`              |
+| H-7 | High     | AuthN Flaw              | `src/web/auth/mod.rs`              |
+| M-1 | Medium   | DNS Security            | `src/servers.rs`                   |
+| M-2 | Medium   | Input Validation        | `src/servers.rs`                   |
+| M-3 | Medium   | Path Traversal          | `src/cli.rs`                       |
+| M-4 | Medium   | Information Leakage     | `src/web/api/auth.rs`              |
+| M-5 | Medium   | Session Management      | `src/web/auth/mod.rs`              |
+| M-6 | Medium   | Missing Controls        | `src/web/mod.rs`                   |
+| M-7 | Medium   | Information Leakage     | `src/config.rs`                    |
+| M-8 | Medium   | DoS                     | `src/zones.rs`                     |
+| M-9 | Medium   | Path Traversal          | `src/cli.rs`                       |
+| M-10| Medium   | Cache Poisoning         | `src/web/doh/mod.rs`               |
+| M-11| Medium   | Session Management      | `src/web/auth/mod.rs`              |
+| M-12| Medium   | CSRF                    | `src/web/ui/admin_ui.rs`           |
+| L-1 | Low      | Information Leakage     | `src/web/auth/mod.rs`              |
+| L-2 | Low      | Functional              | `goat-lib/src/validators.rs`       |
+| L-3 | Low      | DoS / Reliability       | `src/cli.rs`                       |
+| L-4 | Low      | Information Leakage     | `src/packet_dumper.rs`             |
+| L-5 | Low      | Information Leakage     | `src/web/api/`                     |
+| L-6 | Low      | Input Validation        | `src/resourcerecord.rs`            |
+| L-7 | Low      | DoS                     | `src/datastore.rs`                 |
+| L-8 | Low      | XSS                     | `src/enums.rs`                     |

--- a/justfile
+++ b/justfile
@@ -69,7 +69,7 @@ codespell:
 
 # Ask the clip for the judgement
 clippy:
-	cargo clippy --all-features --all-targets --quiet
+	cargo clippy --all-features --all-targets --quiet -- -D warnings
 
 # Run the rust tests
 test:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,8 @@
 //! Code related to CLI things
 //!
 
+use std::path::PathBuf;
+
 use crate::config::ConfigFile;
 use crate::datastore::Command;
 use clap::*;
@@ -13,8 +15,8 @@ use tracing::{debug, error, info, warn};
 
 #[derive(Parser, Clone)]
 pub struct SharedOpts {
-    #[clap(short, long, help = "Configuration file")]
-    config: Option<String>,
+    #[clap(short, long, help = "Configuration file", env = "GOATNS_CONFIG_FILE")]
+    config: Option<PathBuf>,
     #[clap(short, long)]
     debug: bool,
 }
@@ -72,7 +74,7 @@ pub struct Cli {
 }
 
 impl Cli {
-    pub fn config(&self) -> Option<String> {
+    pub fn config(&self) -> Option<PathBuf> {
         match &self.command {
             Commands::Server { sopt } => sopt.config.clone(),
             _ => None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -221,7 +221,7 @@ impl ConfigFile {
     pub fn try_from(config_path: Option<PathBuf>) -> Result<ConfigFile, std::io::Error> {
         let file_locations = match config_path {
             Some(value) => vec![value],
-            None => CONFIG_LOCATIONS.iter().map(|x| PathBuf::from(x)).collect(),
+            None => CONFIG_LOCATIONS.iter().map(PathBuf::from).collect(),
         };
 
         // clean up the file paths and filter them by the ones that exist
@@ -379,11 +379,10 @@ impl From<Config> for ConfigFile {
 
         let mut otel_endpoint = None;
         #[cfg(not(test))]
-        if let Ok(val) = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT") {
-            if !val.is_empty() {
+        if let Ok(val) = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
+            && !val.is_empty() {
                 otel_endpoint = Some(val);
             }
-        }
         if otel_endpoint.is_none() {
             otel_endpoint = config
                 .get("otel_endpoint")

--- a/src/config.rs
+++ b/src/config.rs
@@ -210,7 +210,7 @@ impl ConfigFile {
     ///
     /// The default locations are `~/.config/goatns.json` and `./goatns.json`.
     pub fn try_as_cowcell(
-        config_path: Option<String>,
+        config_path: Option<PathBuf>,
     ) -> Result<CowCell<ConfigFile>, std::io::Error> {
         Ok(CowCell::new(ConfigFile::try_from(config_path)?))
     }
@@ -218,17 +218,17 @@ impl ConfigFile {
     /// Loads the configuration from a given file or from some default locations.
     ///
     /// The default locations are `~/.config/goatns.json` and `./goatns.json`.
-    pub fn try_from(config_path: Option<String>) -> Result<ConfigFile, std::io::Error> {
+    pub fn try_from(config_path: Option<PathBuf>) -> Result<ConfigFile, std::io::Error> {
         let file_locations = match config_path {
-            Some(value) => vec![value.to_owned()],
-            None => CONFIG_LOCATIONS.iter().map(|x| x.to_string()).collect(),
+            Some(value) => vec![value],
+            None => CONFIG_LOCATIONS.iter().map(|x| PathBuf::from(x)).collect(),
         };
 
         // clean up the file paths and filter them by the ones that exist
         let found_files: Vec<String> = file_locations
             .iter()
             .filter_map(|f| {
-                let path = shellexpand::tilde(&f).into_owned();
+                let path = shellexpand::tilde(&f.to_string_lossy()).into_owned();
                 let filepath = std::path::Path::new(&path);
                 match filepath.exists() {
                     false => {
@@ -243,7 +243,11 @@ impl ConfigFile {
         if found_files.is_empty() {
             eprintln!(
                 "No configuration files exist, giving up! Tried: {}",
-                file_locations.join(", ")
+                file_locations
+                    .iter()
+                    .map(|p| p.to_string_lossy())
+                    .collect::<Vec<_>>()
+                    .join(", ")
             );
             return Err(std::io::Error::new(
                 ErrorKind::NotFound,

--- a/src/datastore.rs
+++ b/src/datastore.rs
@@ -28,6 +28,8 @@ pub enum Command {
         rrtype: RecordType,
         /// The class of record to get
         rclass: RecordClass,
+        /// Whether the client set the DO (DNSSEC OK) bit - if true and zone is signed, include RRSIG records
+        do_bit: bool,
         /// The response channel
         resp: Responder<Option<ZoneRecord>>,
     },
@@ -166,6 +168,7 @@ async fn handle_get_command(
     name: Vec<u8>,
     rrtype: RecordType,
     rclass: RecordClass,
+    do_bit: bool,
     resp: oneshot::Sender<Option<ZoneRecord>>,
 ) -> Result<(), String> {
     debug!(
@@ -180,7 +183,19 @@ async fn handle_get_command(
     let mut zr = ZoneRecord {
         name: name.clone(),
         typerecords: vec![],
+        signed: false,
     };
+
+    // look up the zone's signed flag
+    let zone_signed = entities::zones::Entity::find()
+        .filter(entities::zones::Column::Name.eq(db_name.to_string()))
+        .one(conn)
+        .await
+        .ok()
+        .flatten()
+        .map(|z| z.signed)
+        .unwrap_or(false);
+    zr.signed = zone_signed;
 
     //  if it's an SOA record we don't go to the database directly, it's based on the zone, but currently we're only doing this for the specific zone.
 
@@ -208,6 +223,39 @@ async fn handle_get_command(
                 error!("Failed to query db: {err:?}")
             }
         };
+        // if the client set the DO bit and the zone is signed, include RRSIG records
+        if do_bit && zone_signed && rrtype != RecordType::RRSIG {
+            match entities::records_merged::Entity::get_records(
+                conn,
+                db_name,
+                RecordType::RRSIG,
+                rclass,
+                true,
+            )
+            .await
+            {
+                Ok(value) => {
+                    let rrsigs: Vec<InternalResourceRecord> = value
+                        .into_iter()
+                        .filter_map(|rec| InternalResourceRecord::try_from(rec).ok())
+                        .filter(|rr| {
+                            if let InternalResourceRecord::RRSIG {
+                                type_covered, ..
+                            } = rr
+                            {
+                                *type_covered == rrtype
+                            } else {
+                                false
+                            }
+                        })
+                        .collect();
+                    zr.typerecords.extend(rrsigs);
+                }
+                Err(err) => {
+                    error!("Failed to query RRSIG records: {err:?}")
+                }
+            }
+        }
     }
 
     let result = match zr.typerecords.is_empty() {
@@ -436,10 +484,11 @@ pub(crate) async fn handle_message(
             name,
             rrtype,
             rclass,
+            do_bit,
             resp,
         } => {
             let res =
-                handle_get_command(server_hostname, &connpool, name, rrtype, rclass, resp).await;
+                handle_get_command(server_hostname, &connpool, name, rrtype, rclass, do_bit, resp).await;
             if let Err(e) = res {
                 error!("{e:?}")
             };

--- a/src/db/entities/zones.rs
+++ b/src/db/entities/zones.rs
@@ -17,6 +17,7 @@ pub struct Model {
     pub retry: u32,
     pub expire: u32,
     pub minimum: u32,
+    pub signed: bool,
 }
 
 impl PartialEq for Model {
@@ -78,6 +79,7 @@ impl From<ZoneForm> for ActiveModel {
             retry: Set(record.retry),
             expire: Set(record.expire),
             minimum: Set(record.minimum),
+            signed: Set(record.signed),
         };
 
         if let Some(id) = record.id {

--- a/src/db/migrations/m_20260626_dnssec.rs
+++ b/src/db/migrations/m_20260626_dnssec.rs
@@ -1,0 +1,35 @@
+use async_trait::async_trait;
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Zones::Table)
+                    .add_column(
+                        ColumnDef::new(Zones::Signed)
+                            .boolean()
+                            .not_null()
+                            .default(false),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Zones {
+    Table,
+    Signed,
+}

--- a/src/db/migrations/m_20260627_fix_at_sign_name.rs
+++ b/src/db/migrations/m_20260627_fix_at_sign_name.rs
@@ -1,0 +1,36 @@
+use async_trait::async_trait;
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        db.execute_unprepared("DROP VIEW IF EXISTS records_merged;")
+            .await?;
+
+        db.execute_unprepared(
+            r#"CREATE VIEW records_merged ( record_id, zoneid, rrtype, rclass, rdata, name, ttl ) as
+        SELECT records.id as record_id, zones.id as zoneid, records.rrtype, records.rclass, records.rdata,
+        CASE
+            WHEN records.name is NULL OR length(records.name) == 0 OR records.name = '@' THEN zones.name
+            ELSE records.name || '.' || zones.name
+        END AS name,
+        CASE WHEN records.ttl is NULL then zones.minimum
+            WHEN records.ttl > zones.minimum THEN records.ttl
+            ELSE records.ttl
+        END AS ttl
+        from records, zones where records.zoneid = zones.id;"#,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        Ok(())
+    }
+}

--- a/src/db/migrations/mod.rs
+++ b/src/db/migrations/mod.rs
@@ -2,6 +2,8 @@ mod m_20260115_users_table;
 mod m_20260115_zones_tables;
 mod m_20260201_users_id_uuid;
 mod m_20260203_zones_ids_uuid;
+mod m_20260626_dnssec;
+mod m_20260627_fix_at_sign_name;
 
 use async_trait::async_trait;
 use sea_orm_migration::prelude::*;
@@ -16,6 +18,8 @@ impl MigratorTrait for Migrator {
             Box::new(m_20260115_zones_tables::Migration),
             Box::new(m_20260201_users_id_uuid::Migration),
             Box::new(m_20260203_zones_ids_uuid::Migration),
+            Box::new(m_20260626_dnssec::Migration),
+            Box::new(m_20260627_fix_at_sign_name::Migration),
         ]
     }
 }

--- a/src/db/test.rs
+++ b/src/db/test.rs
@@ -95,6 +95,7 @@ pub fn test_example_com_zone() -> entities::zones::ActiveModel {
         serial: Set(0),
         refresh: Set(0),
         retry: Set(0),
+        signed: Set(false),
         expire: Set(0),
         minimum: Set(0),
     }
@@ -299,6 +300,7 @@ async fn test_duplicate_record_constraint() -> Result<(), GoatNsError> {
         serial: Set(1),
         refresh: Set(3600),
         retry: Set(1800),
+        signed: Set(false),
         expire: Set(604800),
         minimum: Set(86400),
     };
@@ -362,6 +364,7 @@ async fn test_record_requires_name() -> Result<(), GoatNsError> {
         serial: Set(1),
         refresh: Set(3600),
         retry: Set(1800),
+        signed: Set(false),
         expire: Set(604800),
         minimum: Set(86400),
     };

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -119,7 +119,23 @@ pub enum RecordType {
     ANY = 255,
     /// Certification Authority Restriction - <https://www.rfc-editor.org/rfc/rfc6844.txt>
     CAA = 257,
-    InvalidType,
+    /// DNSKEY <https://www.rfc-editor.org/rfc/rfc4034>
+    DNSKEY = 48,
+    /// RRSIG <https://www.rfc-editor.org/rfc/rfc4034>
+    RRSIG = 46,
+    /// NSEC <https://www.rfc-editor.org/rfc/rfc4034>
+    NSEC = 47,
+    /// NSEC3 <https://www.rfc-editor.org/rfc/rfc5155>
+    NSEC3 = 50,
+    /// NSEC3PARAM <https://www.rfc-editor.org/rfc/rfc5155>
+    NSEC3PARAM = 51,
+    /// DS <https://www.rfc-editor.org/rfc/rfc4034>
+    DS = 43,
+    /// CDNSKEY <https://www.rfc-editor.org/rfc/rfc7344>
+    CDNSKEY = 60,
+    /// CDS <https://www.rfc-editor.org/rfc/rfc7344>
+    CDS = 59,
+    InvalidType = 254,
 }
 
 impl From<RecordType> for sea_orm::Value {
@@ -159,6 +175,14 @@ impl From<&u16> for RecordType {
             255 => Self::ANY,
             256 => Self::URI,
             257 => Self::CAA,
+            43 => Self::DS,
+            46 => Self::RRSIG,
+            47 => Self::NSEC,
+            48 => Self::DNSKEY,
+            50 => Self::NSEC3,
+            51 => Self::NSEC3PARAM,
+            59 => Self::CDS,
+            60 => Self::CDNSKEY,
             _ => Self::InvalidType,
         }
     }
@@ -195,6 +219,14 @@ impl From<&str> for RecordType {
             "TXT" => Self::TXT,
             "URI" => Self::URI,
             "WKS" => Self::WKS,
+            "DNSKEY" => Self::DNSKEY,
+            "RRSIG" => Self::RRSIG,
+            "NSEC" => Self::NSEC,
+            "NSEC3" => Self::NSEC3,
+            "NSEC3PARAM" => Self::NSEC3PARAM,
+            "DS" => Self::DS,
+            "CDNSKEY" => Self::CDNSKEY,
+            "CDS" => Self::CDS,
             _ => Self::InvalidType,
         }
     }
@@ -225,6 +257,14 @@ impl From<RecordType> for &'static str {
             RecordType::TXT => "TXT",
             RecordType::URI => "URI",
             RecordType::WKS => "WKS",
+            RecordType::DNSKEY => "DNSKEY",
+            RecordType::RRSIG => "RRSIG",
+            RecordType::NSEC => "NSEC",
+            RecordType::NSEC3 => "NSEC3",
+            RecordType::NSEC3PARAM => "NSEC3PARAM",
+            RecordType::DS => "DS",
+            RecordType::CDNSKEY => "CDNSKEY",
+            RecordType::CDS => "CDS",
             RecordType::InvalidType => "",
         }
     }
@@ -244,14 +284,22 @@ impl From<InternalResourceRecord> for RecordType {
             InternalResourceRecord::AAAA { .. } => RecordType::AAAA,
             InternalResourceRecord::AXFR { .. } => RecordType::AXFR,
             InternalResourceRecord::CAA { .. } => RecordType::CAA,
+            InternalResourceRecord::CDNSKEY { .. } => RecordType::CDNSKEY,
+            InternalResourceRecord::CDS { .. } => RecordType::CDS,
             InternalResourceRecord::CNAME { .. } => RecordType::CNAME,
+            InternalResourceRecord::DNSKEY { .. } => RecordType::DNSKEY,
+            InternalResourceRecord::DS { .. } => RecordType::DS,
             InternalResourceRecord::HINFO { .. } => RecordType::HINFO,
             InternalResourceRecord::InvalidType => RecordType::InvalidType,
             InternalResourceRecord::LOC { .. } => RecordType::LOC,
             InternalResourceRecord::MX { .. } => RecordType::MX,
             InternalResourceRecord::NAPTR { .. } => RecordType::NAPTR,
+            InternalResourceRecord::NSEC { .. } => RecordType::NSEC,
+            InternalResourceRecord::NSEC3 { .. } => RecordType::NSEC3,
+            InternalResourceRecord::NSEC3PARAM { .. } => RecordType::NSEC3PARAM,
             InternalResourceRecord::NS { .. } => RecordType::NS,
             InternalResourceRecord::PTR { .. } => RecordType::PTR,
+            InternalResourceRecord::RRSIG { .. } => RecordType::RRSIG,
             InternalResourceRecord::SOA { .. } => RecordType::SOA,
             InternalResourceRecord::TXT { .. } => RecordType::TXT,
             InternalResourceRecord::URI { .. } => RecordType::URI,
@@ -267,12 +315,20 @@ impl RecordType {
             | RecordType::AAAA
             | RecordType::ANY
             | RecordType::CAA
+            | RecordType::CDNSKEY
+            | RecordType::CDS
             | RecordType::CNAME
+            | RecordType::DNSKEY
+            | RecordType::DS
             | RecordType::HINFO
             | RecordType::LOC
             | RecordType::MX
+            | RecordType::NSEC
+            | RecordType::NSEC3
+            | RecordType::NSEC3PARAM
             | RecordType::NS
             | RecordType::PTR
+            | RecordType::RRSIG
             | RecordType::SOA
             | RecordType::TXT
             | RecordType::URI => true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,3 +373,178 @@ impl TryFrom<Question> for Vec<u8> {
         question.try_to_bytes()
     }
 }
+
+#[derive(Clone, Debug)]
+/// EDNS0 OPT pseudo-RR, RFC 6891
+pub struct OptRecord {
+    /// UDP payload size the sender can handle
+    pub udp_payload_size: u16,
+    /// extended RCODE (upper 8 bits of the full 12-bit RCODE)
+    pub extended_rcode: u8,
+    /// EDNS version (must be 0 for EDNS0)
+    pub version: u8,
+    /// DNSSEC OK bit - client requests DNSSEC records
+    pub do_bit: bool,
+    /// additional EDNS options (ignored for now)
+    pub options: Vec<u8>,
+}
+
+impl OptRecord {
+    /// Build an OPT record suitable for a response
+    pub fn response(udp_payload_size: u16, do_bit: bool) -> Self {
+        Self {
+            udp_payload_size,
+            extended_rcode: 0,
+            version: 0,
+            do_bit,
+            options: vec![],
+        }
+    }
+
+    /// true if this record indicates the client supports DNSSEC (DO bit set)
+    pub fn dnssec_ok(&self) -> bool {
+        self.do_bit
+    }
+
+    /// serialize the OPT RR into wire format for the additional section
+    pub fn to_wire(&self) -> Vec<u8> {
+        let mut res = vec![];
+        // name: root label only
+        res.push(0);
+        // type: OPT = 41
+        res.extend((41u16).to_be_bytes());
+        // class: UDP payload size
+        res.extend(self.udp_payload_size.to_be_bytes());
+        // TTL: extended RCODE (bits 31-24), version (bits 23-16), DO bit (bit 15), rest zero
+        let mut ttl: u32 = 0;
+        ttl |= (self.extended_rcode as u32) << 24;
+        ttl |= (self.version as u32) << 16;
+        if self.do_bit {
+            ttl |= 1 << 15;
+        }
+        res.extend(ttl.to_be_bytes());
+        // RDLENGTH
+        res.extend((self.options.len() as u16).to_be_bytes());
+        // RDATA
+        res.extend(&self.options);
+        res
+    }
+
+    /// parse OPT RR from wire format, returns the OPT record and number of bytes consumed
+    pub fn from_wire(input: &[u8]) -> Result<(Self, usize), String> {
+        if input.len() < 11 {
+            return Err("OPT RR too short".to_string());
+        }
+        // name should be root label (0)
+        if input[0] != 0 {
+            return Err("OPT name must be root label".to_string());
+        }
+        // type must be OPT (41)
+        let rrtype = u16::from_be_bytes([input[1], input[2]]);
+        if rrtype != 41 {
+            return Err(format!("OPT type mismatch: got {rrtype}"));
+        }
+        // class = UDP payload size
+        let udp_payload_size = u16::from_be_bytes([input[3], input[4]]);
+        // TTL
+        let ttl = u32::from_be_bytes([input[5], input[6], input[7], input[8]]);
+        let extended_rcode = (ttl >> 24) as u8;
+        let version = (ttl >> 16) as u8;
+        let do_bit = (ttl >> 15) & 1 == 1;
+        // RDLENGTH
+        let rdlength = u16::from_be_bytes([input[9], input[10]]);
+        let total = 11 + rdlength as usize;
+        if input.len() < total {
+            return Err("OPT RR RDATA extends past end".to_string());
+        }
+        let options = input[11..total].to_vec();
+        Ok((
+            Self {
+                udp_payload_size,
+                extended_rcode,
+                version,
+                do_bit,
+                options,
+            },
+            total,
+        ))
+    }
+}
+
+/// Parse the additional section of a DNS message, returning any OPT RR found and the DO bit.
+/// The additional section starts right after the question section.
+pub fn parse_opt_from_additional(buf: &[u8], question_end: usize) -> (Option<OptRecord>, bool) {
+    let mut pos = question_end;
+    let mut opt = None;
+    let mut do_bit = false;
+
+    while pos < buf.len() {
+        if buf.len() < pos + 11 {
+            break;
+        }
+        let Some(rr_end) = parse_rr_end(buf, pos) else {
+            break;
+        };
+        let rr_buf = &buf[pos..rr_end];
+        if rr_buf[0] == 0 && rr_buf[1..3] == [0, 41] {
+            if let Ok((parsed, _)) = OptRecord::from_wire(rr_buf) {
+                do_bit = parsed.do_bit;
+                opt = Some(parsed);
+            }
+            break;
+        };
+        pos = rr_end;
+    }
+
+    (opt, do_bit)
+}
+
+/// Calculate the wire-format length of a qname (labels + type + class).
+/// The qname is stored as the dotted-name string (e.g. "example.com"), so wire length
+/// is: sum of (label_len + 1) for each label + 1 for the terminating 0 + 4 for qtype+qclass.
+pub fn question_qname_wire_len(qname: &[u8]) -> usize {
+    if qname.is_empty() {
+        return 1 + 4; // root label + qtype + qclass
+    }
+    let mut len = 0;
+    let mut pos = 0;
+    while pos < qname.len() {
+        if qname[pos] == b'.' {
+            len += 1; // length octet for the next label
+            pos += 1;
+        } else {
+            len += 1; // the character itself
+            pos += 1;
+        }
+    }
+    len += 1; // first label length octet (not counted in the loop)
+    len += 1; // terminating 0
+    len += 4; // qtype + qclass
+    len
+}
+
+fn parse_rr_end(buf: &[u8], pos: usize) -> Option<usize> {
+    if pos >= buf.len() {
+        return None;
+    }
+    let mut p = pos;
+    // skip name: labels until 0 byte
+    while p < buf.len() && buf[p] != 0 {
+        let label_len = buf[p] as usize;
+        p += label_len + 1;
+    }
+    if p >= buf.len() {
+        return None;
+    }
+    p += 1; // skip the terminating 0
+    // skip type(2) + class(2) + ttl(4) + rdlength(2) = 10 bytes
+    if p + 10 > buf.len() {
+        return None;
+    }
+    let rdlength = u16::from_be_bytes([buf[p + 8], buf[p + 9]]) as usize;
+    p += 10 + rdlength;
+    if p > buf.len() {
+        return None;
+    }
+    Some(p)
+}

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -1,8 +1,8 @@
 use crate::enums::{PacketType, Rcode};
 use crate::error::GoatNsError;
 use crate::resourcerecord::{DNSCharString, InternalResourceRecord};
-use crate::{Header, Question};
-use crate::{ResourceRecord, UDP_BUFFER_SIZE};
+use crate::{Header, Question, ResourceRecord};
+use crate::UDP_BUFFER_SIZE;
 use packed_struct::prelude::*;
 use tracing::{debug, error};
 
@@ -11,8 +11,8 @@ pub struct Reply {
     pub header: Header,
     pub question: Option<Question>,
     pub answers: Vec<InternalResourceRecord>,
-    pub authorities: Vec<ResourceRecord>,
-    pub additional: Vec<ResourceRecord>,
+    pub authorities: Vec<Vec<u8>>,
+    pub additional: Vec<Vec<u8>>,
 }
 
 impl Reply {
@@ -37,14 +37,22 @@ impl Reply {
                     InternalResourceRecord::AAAA { ttl, .. } => ttl,
                     InternalResourceRecord::AXFR { ttl, .. } => ttl,
                     InternalResourceRecord::CAA { ttl, .. } => ttl,
+                    InternalResourceRecord::CDNSKEY { ttl, .. } => ttl,
+                    InternalResourceRecord::CDS { ttl, .. } => ttl,
                     InternalResourceRecord::CNAME { ttl, .. } => ttl,
+                    InternalResourceRecord::DNSKEY { ttl, .. } => ttl,
+                    InternalResourceRecord::DS { ttl, .. } => ttl,
                     InternalResourceRecord::HINFO { ttl, .. } => ttl,
                     InternalResourceRecord::InvalidType => &1u32,
                     InternalResourceRecord::LOC { ttl, .. } => ttl,
                     InternalResourceRecord::MX { ttl, .. } => ttl,
                     InternalResourceRecord::NAPTR { ttl, .. } => ttl,
+                    InternalResourceRecord::NSEC { ttl, .. } => ttl,
+                    InternalResourceRecord::NSEC3 { ttl, .. } => ttl,
+                    InternalResourceRecord::NSEC3PARAM { ttl, .. } => ttl,
                     InternalResourceRecord::NS { ttl, .. } => ttl,
                     InternalResourceRecord::PTR { ttl, .. } => ttl,
+                    InternalResourceRecord::RRSIG { ttl, .. } => ttl,
                     InternalResourceRecord::SOA { minimum, .. } => minimum,
                     InternalResourceRecord::TXT { ttl, .. } => ttl,
                     InternalResourceRecord::URI { ttl, .. } => ttl,
@@ -70,10 +78,7 @@ impl Reply {
         }
 
         for additional in &final_reply.additional {
-            error!(
-                "Should be handling additional rr's in reply: {:?}",
-                additional
-            );
+            retval.extend(additional);
         }
 
         Ok(retval)

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -96,8 +96,8 @@ impl Reply {
 
     /// checks to see if it's over the max length set in [UDP_BUFFER_SIZE] and set the truncated flag if it is
     pub async fn check_set_truncated(&self) -> Reply {
-        if let Ok(ret_bytes) = self.as_bytes().await {
-            if ret_bytes.len() > UDP_BUFFER_SIZE {
+        if let Ok(ret_bytes) = self.as_bytes().await
+            && ret_bytes.len() > UDP_BUFFER_SIZE {
                 let mut header = self.header.clone();
                 header.truncated = true;
                 return Self {
@@ -105,7 +105,6 @@ impl Reply {
                     ..self.clone()
                 };
             }
-        }
         self.clone()
     }
 }

--- a/src/resourcerecord.rs
+++ b/src/resourcerecord.rs
@@ -314,7 +314,104 @@ pub enum InternalResourceRecord {
         ttl: u32,
         rclass: RecordClass,
     },
+    DNSKEY {
+        flags: u16,
+        protocol: u8,
+        algorithm: u8,
+        public_key: Vec<u8>,
+        ttl: u32,
+        rclass: RecordClass,
+    },
+    RRSIG {
+        type_covered: RecordType,
+        algorithm: u8,
+        labels: u8,
+        original_ttl: u32,
+        signature_expiration: u32,
+        signature_inception: u32,
+        key_tag: u16,
+        signer_name: DomainName,
+        signature: Vec<u8>,
+        ttl: u32,
+        rclass: RecordClass,
+    },
+    NSEC {
+        next_domain_name: DomainName,
+        type_bit_maps: Vec<u8>,
+        ttl: u32,
+        rclass: RecordClass,
+    },
+    NSEC3 {
+        hash_algorithm: u8,
+        flags: u8,
+        iterations: u16,
+        salt: Vec<u8>,
+        next_hashed_owner_name: Vec<u8>,
+        type_bit_maps: Vec<u8>,
+        ttl: u32,
+        rclass: RecordClass,
+    },
+    NSEC3PARAM {
+        hash_algorithm: u8,
+        flags: u8,
+        iterations: u16,
+        salt: Vec<u8>,
+        ttl: u32,
+        rclass: RecordClass,
+    },
+    DS {
+        key_tag: u16,
+        algorithm: u8,
+        digest_type: u8,
+        digest: Vec<u8>,
+        ttl: u32,
+        rclass: RecordClass,
+    },
+    CDNSKEY {
+        flags: u16,
+        protocol: u8,
+        algorithm: u8,
+        public_key: Vec<u8>,
+        ttl: u32,
+        rclass: RecordClass,
+    },
+    CDS {
+        key_tag: u16,
+        algorithm: u8,
+        digest_type: u8,
+        digest: Vec<u8>,
+        ttl: u32,
+        rclass: RecordClass,
+    },
     InvalidType,
+}
+
+fn parse_domain_name_from_wire(input: &[u8]) -> Result<(DomainName, Vec<u8>), GoatNsError> {
+    let mut labels: Vec<&str> = Vec::new();
+    let mut pos = 0;
+    while pos < input.len() {
+        let label_len = input[pos] as usize;
+        if label_len == 0 {
+            pos += 1;
+            break;
+        }
+        if pos + 1 + label_len > input.len() {
+            return Err(GoatNsError::Generic(
+                "domain name label extends past end of rdata".to_string(),
+            ));
+        }
+        let label = from_utf8(&input[pos + 1..pos + 1 + label_len]).map_err(|e| {
+            GoatNsError::Generic(format!("invalid utf8 in domain name label: {e:?}"))
+        })?;
+        labels.push(label);
+        pos += 1 + label_len;
+    }
+    let name = if labels.is_empty() {
+        ".".to_string()
+    } else {
+        labels.join(".")
+    };
+    Ok((DomainName::from(name), input[pos..].to_vec()))
 }
 
 impl InternalResourceRecord {
@@ -324,14 +421,22 @@ impl InternalResourceRecord {
             InternalResourceRecord::AAAA { .. } => rrtype == RecordType::AAAA,
             InternalResourceRecord::AXFR { .. } => rrtype == RecordType::AXFR,
             InternalResourceRecord::CAA { .. } => rrtype == RecordType::CAA,
+            InternalResourceRecord::CDNSKEY { .. } => rrtype == RecordType::CDNSKEY,
+            InternalResourceRecord::CDS { .. } => rrtype == RecordType::CDS,
             InternalResourceRecord::CNAME { .. } => rrtype == RecordType::CNAME,
+            InternalResourceRecord::DNSKEY { .. } => rrtype == RecordType::DNSKEY,
+            InternalResourceRecord::DS { .. } => rrtype == RecordType::DS,
             InternalResourceRecord::HINFO { .. } => rrtype == RecordType::HINFO,
             InternalResourceRecord::InvalidType => rrtype == RecordType::InvalidType,
             InternalResourceRecord::LOC { .. } => rrtype == RecordType::LOC,
             InternalResourceRecord::MX { .. } => rrtype == RecordType::MX,
             InternalResourceRecord::NAPTR { .. } => rrtype == RecordType::NAPTR,
+            InternalResourceRecord::NSEC { .. } => rrtype == RecordType::NSEC,
+            InternalResourceRecord::NSEC3 { .. } => rrtype == RecordType::NSEC3,
+            InternalResourceRecord::NSEC3PARAM { .. } => rrtype == RecordType::NSEC3PARAM,
             InternalResourceRecord::NS { .. } => rrtype == RecordType::NS,
             InternalResourceRecord::PTR { .. } => rrtype == RecordType::PTR,
+            InternalResourceRecord::RRSIG { .. } => rrtype == RecordType::RRSIG,
             InternalResourceRecord::SOA { .. } => rrtype == RecordType::SOA,
             InternalResourceRecord::TXT { .. } => rrtype == RecordType::TXT,
             InternalResourceRecord::URI { .. } => rrtype == RecordType::URI,
@@ -339,9 +444,391 @@ impl InternalResourceRecord {
     }
 }
 
+impl InternalResourceRecord {
+    pub fn new(
+        name: &str,
+        rrtype: u16,
+        rdata: &str,
+        ttl: u32,
+        rclass: u16,
+    ) -> Result<Self, GoatNsError> {
+    let rclass = RecordClass::from(&rclass);
+    match RecordType::from(&rrtype) {
+        RecordType::A => {
+            let address: u32 = match std::net::Ipv4Addr::from_str(rdata) {
+                Ok(value) => value.into(),
+                Err(error) => {
+                    error!("Failed to parse {rdata:?} into an IPv4 address: {error:?}");
+                    0u32
+                }
+            };
+            Ok(InternalResourceRecord::A {
+                address,
+                ttl,
+                rclass,
+            })
+        }
+        RecordType::AAAA => {
+            let address: u128 = match std::net::Ipv6Addr::from_str(rdata) {
+                Ok(value) => {
+                    let res: u128 = value.into();
+                    trace!("Encoding {value:?} as {res:?}");
+                    res
+                }
+                Err(error) => {
+                    return Err(GoatNsError::Generic(format!(
+                        "Failed to parse {rdata:?} into an IPv6 address: {error:?}"
+                    )));
+                }
+            };
+            Ok(InternalResourceRecord::AAAA {
+                address,
+                ttl,
+                rclass,
+            })
+        }
+        RecordType::CNAME => Ok(InternalResourceRecord::CNAME {
+            cname: DomainName::from(rdata),
+            ttl,
+            rclass,
+        }),
+        RecordType::PTR => Ok(InternalResourceRecord::PTR {
+            ptrdname: DomainName::from(rdata),
+            ttl,
+            rclass,
+        }),
+        RecordType::TXT => Ok(InternalResourceRecord::TXT {
+            txtdata: DNSCharString {
+                data: rdata.as_bytes().to_vec(),
+            },
+            ttl,
+            class: rclass,
+        }),
+        RecordType::MX => {
+            let split_bit: Vec<&str> = rdata.split(' ').collect();
+            if split_bit.len() != 2 {
+                return Err(GoatNsError::Generic(format!(
+                    "While trying to parse MX record, got '{split_bit:?}' which is wrong."
+                )));
+            };
+            let pref = match u16::from_str(split_bit[0]) {
+                Ok(value) => value,
+                Err(error) => {
+                    return Err(GoatNsError::Generic(format!(
+                        "Failed to parse {} into number: {error:?}",
+                        split_bit[0]
+                    )));
+                }
+            };
+            trace!("got pref {}, now {pref}", split_bit[0]);
+            Ok(InternalResourceRecord::MX {
+                preference: pref,
+                exchange: DomainName::from(split_bit[1]),
+                ttl,
+                rclass,
+            })
+        }
+        RecordType::NS => Ok(InternalResourceRecord::NS {
+            nsdname: DomainName::from(rdata),
+            ttl,
+            rclass,
+        }),
+        RecordType::CAA => {
+            let split_bit: Vec<&str> = rdata.split(' ').collect();
+            if split_bit.len() < 3 {
+                return Err(GoatNsError::Generic(format!(
+                    "While trying to parse CAA record, got '{split_bit:?}' which is wrong."
+                )));
+            };
+            let flag = match u8::from_str(split_bit[0]) {
+                Ok(value) => value,
+                Err(error) => {
+                    return Err(GoatNsError::Generic(format!(
+                        "Failed to parse {} into number: {error:?}",
+                        split_bit[0]
+                    )));
+                }
+            };
+            let tag = DNSCharString::from(split_bit[1]);
+            if !CAA_TAG_VALIDATOR.is_match(split_bit[1]) {
+                return Err(GoatNsError::Generic(format!(
+                    "Invalid tag value {:?} for {}",
+                    split_bit[1], name
+                )));
+            };
+            let value = split_bit[2..].to_vec().join(" ").as_bytes().to_vec();
+            Ok(InternalResourceRecord::CAA {
+                flag,
+                tag,
+                value,
+                ttl,
+                rclass,
+            })
+        }
+        RecordType::LOC => {
+            let res: FileLocRecord = FileLocRecord::try_from(rdata)?;
+            Ok(InternalResourceRecord::LOC {
+                ttl,
+                rclass,
+                version: 0,
+                size: res.size,
+                horiz_pre: res.horiz_pre,
+                vert_pre: res.vert_pre,
+                latitude: dms_to_u32(res.d1, res.m1, res.s1, res.lat_dir == *"N"),
+                longitude: dms_to_u32(res.d2, res.m2, res.s2, res.lon_dir == *"E"),
+                altitude: res.alt,
+            })
+        }
+        RecordType::URI => {
+            let matches = match URI_RECORD.captures(rdata) {
+                Some(value) => value,
+                None => {
+                    return Err(GoatNsError::Generic(
+                        "Failed to parse URL record!".to_string(),
+                    ));
+                }
+            };
+            let priority = match matches.name("priority") {
+                Some(value) => match value.as_str().parse::<u16>() {
+                    Ok(value) => value,
+                    Err(err) => {
+                        return Err(GoatNsError::Generic(format!(
+                            "Failed to parse priority into u16: {err:?}"
+                        )));
+                    }
+                },
+                None => {
+                    return Err(GoatNsError::Generic(
+                        "No target found in record?".to_string(),
+                    ));
+                }
+            };
+            let weight = match matches.name("weight") {
+                Some(value) => match value.as_str().parse::<u16>() {
+                    Ok(value) => value,
+                    Err(err) => {
+                        return Err(GoatNsError::Generic(format!(
+                            "Failed to parse weight into u16: {err:?}"
+                        )));
+                    }
+                },
+                None => {
+                    return Err(GoatNsError::Generic(
+                        "No target found in record?".to_string(),
+                    ));
+                }
+            };
+            let target = match matches.name("target") {
+                Some(value) => DNSCharString::from(value.as_str()),
+                None => {
+                    return Err(GoatNsError::Generic(
+                        "No target found in record?".to_string(),
+                    ));
+                }
+            };
+            Ok(InternalResourceRecord::URI {
+                priority,
+                weight,
+                target,
+                ttl,
+                rclass,
+            })
+        }
+        RecordType::DNSKEY => {
+            let bytes = hex::decode(rdata)
+                .map_err(|e| GoatNsError::Generic(format!("Failed to hex-decode DNSKEY rdata: {e:?}")))?;
+            if bytes.len() < 4 {
+                return Err(GoatNsError::Generic(
+                    "DNSKEY rdata too short (need >= 4 bytes)".to_string(),
+                ));
+            }
+            let flags = u16::from_be_bytes([bytes[0], bytes[1]]);
+            let protocol = bytes[2];
+            let algorithm = bytes[3];
+            let public_key = bytes[4..].to_vec();
+            Ok(InternalResourceRecord::DNSKEY {
+                flags,
+                protocol,
+                algorithm,
+                public_key,
+                ttl,
+                rclass,
+            })
+        }
+        RecordType::DS => {
+            let bytes = hex::decode(rdata)
+                .map_err(|e| GoatNsError::Generic(format!("Failed to hex-decode DS rdata: {e:?}")))?;
+            if bytes.len() < 4 {
+                return Err(GoatNsError::Generic(
+                    "DS rdata too short (need >= 4 bytes)".to_string(),
+                ));
+            }
+            let key_tag = u16::from_be_bytes([bytes[0], bytes[1]]);
+            let algorithm = bytes[2];
+            let digest_type = bytes[3];
+            let digest = bytes[4..].to_vec();
+            Ok(InternalResourceRecord::DS {
+                key_tag,
+                algorithm,
+                digest_type,
+                digest,
+                ttl,
+                rclass,
+            })
+        }
+        RecordType::CDNSKEY => {
+            let bytes = hex::decode(rdata).map_err(|e| {
+                GoatNsError::Generic(format!("Failed to hex-decode CDNSKEY rdata: {e:?}"))
+            })?;
+            if bytes.len() < 4 {
+                return Err(GoatNsError::Generic(
+                    "CDNSKEY rdata too short (need >= 4 bytes)".to_string(),
+                ));
+            }
+            let flags = u16::from_be_bytes([bytes[0], bytes[1]]);
+            let protocol = bytes[2];
+            let algorithm = bytes[3];
+            let public_key = bytes[4..].to_vec();
+            Ok(InternalResourceRecord::CDNSKEY {
+                flags,
+                protocol,
+                algorithm,
+                public_key,
+                ttl,
+                rclass,
+            })
+        }
+        RecordType::CDS => {
+            let bytes = hex::decode(rdata)
+                .map_err(|e| GoatNsError::Generic(format!("Failed to hex-decode CDS rdata: {e:?}")))?;
+            if bytes.len() < 4 {
+                return Err(GoatNsError::Generic(
+                    "CDS rdata too short (need >= 4 bytes)".to_string(),
+                ));
+            }
+            let key_tag = u16::from_be_bytes([bytes[0], bytes[1]]);
+            let algorithm = bytes[2];
+            let digest_type = bytes[3];
+            let digest = bytes[4..].to_vec();
+            Ok(InternalResourceRecord::CDS {
+                key_tag,
+                algorithm,
+                digest_type,
+                digest,
+                ttl,
+                rclass,
+            })
+        }
+        RecordType::RRSIG => {
+            let bytes = hex::decode(rdata)
+                .map_err(|e| GoatNsError::Generic(format!("Failed to hex-decode RRSIG rdata: {e:?}")))?;
+            if bytes.len() < 18 {
+                return Err(GoatNsError::Generic(
+                    "RRSIG rdata too short (need >= 18 bytes before signer name)".to_string(),
+                ));
+            }
+            let type_covered = RecordType::from(&u16::from_be_bytes([bytes[0], bytes[1]]));
+            let algorithm = bytes[2];
+            let labels = bytes[3];
+            let original_ttl = u32::from_be_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+            let signature_expiration = u32::from_be_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]);
+            let signature_inception = u32::from_be_bytes([bytes[12], bytes[13], bytes[14], bytes[15]]);
+            let key_tag = u16::from_be_bytes([bytes[16], bytes[17]]);
+            let (signer_name, rest) = parse_domain_name_from_wire(&bytes[18..])?;
+            let signature = rest.to_vec();
+            Ok(InternalResourceRecord::RRSIG {
+                type_covered,
+                algorithm,
+                labels,
+                original_ttl,
+                signature_expiration,
+                signature_inception,
+                key_tag,
+                signer_name,
+                signature,
+                ttl,
+                rclass,
+            })
+        }
+        RecordType::NSEC => {
+            let bytes = hex::decode(rdata)
+                .map_err(|e| GoatNsError::Generic(format!("Failed to hex-decode NSEC rdata: {e:?}")))?;
+            let (next_domain_name, rest) = parse_domain_name_from_wire(&bytes)?;
+            let type_bit_maps = rest.to_vec();
+            Ok(InternalResourceRecord::NSEC {
+                next_domain_name,
+                type_bit_maps,
+                ttl,
+                rclass,
+            })
+        }
+        RecordType::NSEC3 => {
+            let bytes = hex::decode(rdata)
+                .map_err(|e| GoatNsError::Generic(format!("Failed to hex-decode NSEC3 rdata: {e:?}")))?;
+            if bytes.len() < 5 {
+                return Err(GoatNsError::Generic("NSEC3 rdata too short".to_string()));
+            }
+            let hash_algorithm = bytes[0];
+            let flags = bytes[1];
+            let iterations = u16::from_be_bytes([bytes[2], bytes[3]]);
+            let salt_len = bytes[4] as usize;
+            if bytes.len() < 5 + salt_len + 1 {
+                return Err(GoatNsError::Generic(
+                    "NSEC3 rdata too short for salt".to_string(),
+                ));
+            }
+            let salt = bytes[5..5 + salt_len].to_vec();
+            let hash_len = bytes[5 + salt_len] as usize;
+            if bytes.len() < 5 + salt_len + 1 + hash_len {
+                return Err(GoatNsError::Generic(
+                    "NSEC3 rdata too short for hash".to_string(),
+                ));
+            }
+            let next_hashed_owner_name =
+                bytes[5 + salt_len + 1..5 + salt_len + 1 + hash_len].to_vec();
+            let type_bit_maps = bytes[5 + salt_len + 1 + hash_len..].to_vec();
+            Ok(InternalResourceRecord::NSEC3 {
+                hash_algorithm,
+                flags,
+                iterations,
+                salt,
+                next_hashed_owner_name,
+                type_bit_maps,
+                ttl,
+                rclass,
+            })
+        }
+        RecordType::NSEC3PARAM => {
+            let bytes = hex::decode(rdata).map_err(|e| {
+                GoatNsError::Generic(format!("Failed to hex-decode NSEC3PARAM rdata: {e:?}"))
+            })?;
+            if bytes.len() < 5 {
+                return Err(GoatNsError::Generic(
+                    "NSEC3PARAM rdata too short".to_string(),
+                ));
+            }
+            let hash_algorithm = bytes[0];
+            let flags = bytes[1];
+            let iterations = u16::from_be_bytes([bytes[2], bytes[3]]);
+            let salt_len = bytes[4] as usize;
+            let salt = bytes[5..5 + salt_len].to_vec();
+            Ok(InternalResourceRecord::NSEC3PARAM {
+                hash_algorithm,
+                flags,
+                iterations,
+                salt,
+                ttl,
+                rclass,
+            })
+        }
+        _ => Err(GoatNsError::Generic("Invalid type specified!".to_string())),
+    }
+}
+
+}
+
 impl TryFrom<entities::records::Model> for InternalResourceRecord {
     type Error = GoatNsError;
-    /// This is where we convert from the JSON blob in the file to an internal representation of the data.
     fn try_from(record: entities::records::Model) -> Result<Self, Self::Error> {
         if check_long_labels(&record.name) {
             return Err(GoatNsError::Generic(format!(
@@ -365,201 +852,7 @@ impl TryFrom<entities::records::Model> for InternalResourceRecord {
             )));
         };
 
-        match RecordType::from(&record.rrtype) {
-            RecordType::A => {
-                let address: u32 = match std::net::Ipv4Addr::from_str(&record.rdata) {
-                    Ok(value) => value.into(),
-                    Err(error) => {
-                        error!(
-                            "Failed to parse {:?} into an IPv4 address: {:?}",
-                            record.rdata, error
-                        );
-                        0u32
-                    }
-                };
-                Ok(InternalResourceRecord::A {
-                    address,
-                    ttl,
-                    rclass: RecordClass::from(&record.rclass),
-                })
-            }
-            RecordType::AAAA => {
-                let address: u128 = match std::net::Ipv6Addr::from_str(&record.rdata) {
-                    Ok(value) => {
-                        let res: u128 = value.into();
-                        trace!("Encoding {:?} as {:?}", value, res);
-                        res
-                    }
-                    Err(error) => {
-                        return Err(GoatNsError::Generic(format!(
-                            "Failed to parse {:?} into an IPv6 address: {:?}",
-                            record.rdata, error
-                        )));
-                    }
-                };
-
-                Ok(InternalResourceRecord::AAAA {
-                    address,
-                    ttl,
-                    rclass: RecordClass::from(&record.rclass),
-                })
-            }
-            RecordType::CNAME => Ok(InternalResourceRecord::CNAME {
-                cname: DomainName::from(record.rdata),
-                ttl,
-                rclass: RecordClass::from(&record.rclass),
-            }),
-            RecordType::PTR => Ok(InternalResourceRecord::PTR {
-                ptrdname: DomainName::from(record.rdata),
-                ttl,
-                rclass: RecordClass::from(&record.rclass),
-            }),
-            RecordType::TXT => Ok(InternalResourceRecord::TXT {
-                txtdata: DNSCharString {
-                    data: record.rdata.into_bytes(),
-                },
-                ttl,
-                class: RecordClass::from(&record.rclass),
-            }),
-            RecordType::MX => {
-                let split_bit: Vec<&str> = record.rdata.split(' ').collect();
-                if split_bit.len() != 2 {
-                    return Err(GoatNsError::Generic(format!(
-                        "While trying to parse MX record, got '{split_bit:?}' which is wrong."
-                    )));
-                };
-                let pref = match u16::from_str(split_bit[0]) {
-                    Ok(value) => value,
-                    Err(error) => {
-                        return Err(GoatNsError::Generic(format!(
-                            "Failed to parse {} into number: {:?}",
-                            split_bit[0], error
-                        )));
-                    }
-                };
-                trace!("got pref {}, now {pref}", split_bit[0]);
-                Ok(InternalResourceRecord::MX {
-                    preference: pref,
-                    exchange: DomainName::from(split_bit[1]),
-                    ttl,
-                    rclass: RecordClass::from(&record.rclass),
-                })
-            }
-            RecordType::NS => Ok(InternalResourceRecord::NS {
-                nsdname: DomainName::from(record.rdata),
-                ttl,
-                rclass: RecordClass::from(&record.rclass),
-            }),
-            RecordType::CAA => {
-                let split_bit: Vec<&str> = record.rdata.split(' ').collect();
-                if split_bit.len() < 3 {
-                    return Err(GoatNsError::Generic(format!(
-                        "While trying to parse CAA record, got '{split_bit:?}' which is wrong."
-                    )));
-                };
-                let flag = match u8::from_str(split_bit[0]) {
-                    Ok(value) => value,
-                    Err(error) => {
-                        return Err(GoatNsError::Generic(format!(
-                            "Failed to parse {} into number: {:?}",
-                            split_bit[0], error
-                        )));
-                    }
-                };
-                let tag = DNSCharString::from(split_bit[1]);
-                // validate that the tag is valid.
-                if !CAA_TAG_VALIDATOR.is_match(split_bit[1]) {
-                    return Err(GoatNsError::Generic(format!(
-                        "Invalid tag value {:?} for {}",
-                        split_bit[1], record.name
-                    )));
-                };
-                // take the rest of the data as the thing.
-                let value = split_bit[2..].to_vec().join(" ").as_bytes().to_vec();
-                Ok(InternalResourceRecord::CAA {
-                    flag,
-                    tag,
-                    value,
-                    ttl,
-                    rclass: RecordClass::from(&record.rclass),
-                })
-            }
-            RecordType::LOC => {
-                // we do this here because the conversion process is *so* big.
-                let res: FileLocRecord = FileLocRecord::try_from(record.rdata.as_str())?;
-
-                Ok(InternalResourceRecord::LOC {
-                    ttl,
-                    rclass: RecordClass::from(&record.rclass),
-                    version: 0,
-                    size: res.size,
-                    horiz_pre: res.horiz_pre,
-                    vert_pre: res.vert_pre,
-                    latitude: dms_to_u32(res.d1, res.m1, res.s1, res.lat_dir == *"N"),
-                    longitude: dms_to_u32(res.d2, res.m2, res.s2, res.lon_dir == *"E"),
-                    altitude: res.alt,
-                })
-                // Err("LOC not finished!".to_string())
-            }
-            RecordType::URI => {
-                let matches = match URI_RECORD.captures(&record.rdata) {
-                    Some(value) => value,
-                    None => {
-                        return Err(GoatNsError::Generic(
-                            "Failed to parse URL record!".to_string(),
-                        ));
-                    }
-                };
-
-                let priority = match matches.name("priority") {
-                    Some(value) => match value.as_str().parse::<u16>() {
-                        Ok(value) => value,
-                        Err(err) => {
-                            return Err(GoatNsError::Generic(format!(
-                                "Failed to parse priority into u16: {err:?}"
-                            )));
-                        }
-                    },
-                    None => {
-                        return Err(GoatNsError::Generic(
-                            "No target found in record?".to_string(),
-                        ));
-                    }
-                };
-                let weight = match matches.name("weight") {
-                    Some(value) => match value.as_str().parse::<u16>() {
-                        Ok(value) => value,
-                        Err(err) => {
-                            return Err(GoatNsError::Generic(format!(
-                                "Failed to parse weight into u16: {err:?}"
-                            )));
-                        }
-                    },
-                    None => {
-                        return Err(GoatNsError::Generic(
-                            "No target found in record?".to_string(),
-                        ));
-                    }
-                };
-                let target = match matches.name("target") {
-                    Some(value) => DNSCharString::from(value.as_str()),
-                    None => {
-                        return Err(GoatNsError::Generic(
-                            "No target found in record?".to_string(),
-                        ));
-                    }
-                };
-
-                Ok(InternalResourceRecord::URI {
-                    priority,
-                    weight,
-                    target,
-                    ttl,
-                    rclass: RecordClass::from(&record.rclass),
-                })
-            }
-            _ => Err(GoatNsError::Generic("Invalid type specified!".to_string())),
-        }
+        Self::new(&record.name, record.rrtype, &record.rdata, ttl, record.rclass)
     }
 }
 
@@ -582,201 +875,7 @@ impl TryFrom<entities::records_merged::Model> for InternalResourceRecord {
             )));
         };
 
-        match RecordType::from(&record.rrtype) {
-            RecordType::A => {
-                let address: u32 = match std::net::Ipv4Addr::from_str(&record.rdata) {
-                    Ok(value) => value.into(),
-                    Err(error) => {
-                        error!(
-                            "Failed to parse {:?} into an IPv4 address: {:?}",
-                            record.rdata, error
-                        );
-                        0u32
-                    }
-                };
-                Ok(InternalResourceRecord::A {
-                    address,
-                    ttl: record.ttl,
-                    rclass: RecordClass::from(&record.rclass),
-                })
-            }
-            RecordType::AAAA => {
-                let address: u128 = match std::net::Ipv6Addr::from_str(&record.rdata) {
-                    Ok(value) => {
-                        let res: u128 = value.into();
-                        trace!("Encoding {:?} as {:?}", value, res);
-                        res
-                    }
-                    Err(error) => {
-                        return Err(GoatNsError::Generic(format!(
-                            "Failed to parse {:?} into an IPv6 address: {:?}",
-                            record.rdata, error
-                        )));
-                    }
-                };
-
-                Ok(InternalResourceRecord::AAAA {
-                    address,
-                    ttl: record.ttl,
-                    rclass: RecordClass::from(&record.rclass),
-                })
-            }
-            RecordType::CNAME => Ok(InternalResourceRecord::CNAME {
-                cname: DomainName::from(record.rdata),
-                ttl: record.ttl,
-                rclass: RecordClass::from(&record.rclass),
-            }),
-            RecordType::PTR => Ok(InternalResourceRecord::PTR {
-                ptrdname: DomainName::from(record.rdata),
-                ttl: record.ttl,
-                rclass: RecordClass::from(&record.rclass),
-            }),
-            RecordType::TXT => Ok(InternalResourceRecord::TXT {
-                txtdata: DNSCharString {
-                    data: record.rdata.into_bytes(),
-                },
-                ttl: record.ttl,
-                class: RecordClass::from(&record.rclass),
-            }),
-            RecordType::MX => {
-                let split_bit: Vec<&str> = record.rdata.split(' ').collect();
-                if split_bit.len() != 2 {
-                    return Err(GoatNsError::Generic(format!(
-                        "While trying to parse MX record, got '{split_bit:?}' which is wrong."
-                    )));
-                };
-                let pref = match u16::from_str(split_bit[0]) {
-                    Ok(value) => value,
-                    Err(error) => {
-                        return Err(GoatNsError::Generic(format!(
-                            "Failed to parse {} into number: {:?}",
-                            split_bit[0], error
-                        )));
-                    }
-                };
-                trace!("got pref {}, now {pref}", split_bit[0]);
-                Ok(InternalResourceRecord::MX {
-                    preference: pref,
-                    exchange: DomainName::from(split_bit[1]),
-                    ttl: record.ttl,
-                    rclass: RecordClass::from(&record.rclass),
-                })
-            }
-            RecordType::NS => Ok(InternalResourceRecord::NS {
-                nsdname: DomainName::from(record.rdata),
-                ttl: record.ttl,
-                rclass: RecordClass::from(&record.rclass),
-            }),
-            RecordType::CAA => {
-                let split_bit: Vec<&str> = record.rdata.split(' ').collect();
-                if split_bit.len() < 3 {
-                    return Err(GoatNsError::Generic(format!(
-                        "While trying to parse CAA record, got '{split_bit:?}' which is wrong."
-                    )));
-                };
-                let flag = match u8::from_str(split_bit[0]) {
-                    Ok(value) => value,
-                    Err(error) => {
-                        return Err(GoatNsError::Generic(format!(
-                            "Failed to parse {} into number: {:?}",
-                            split_bit[0], error
-                        )));
-                    }
-                };
-                let tag = DNSCharString::from(split_bit[1]);
-                // validate that the tag is valid.
-                if !CAA_TAG_VALIDATOR.is_match(split_bit[1]) {
-                    return Err(GoatNsError::Generic(format!(
-                        "Invalid tag value {:?} for {}",
-                        split_bit[1], record.name
-                    )));
-                };
-                // take the rest of the data as the thing.
-                let value = split_bit[2..].to_vec().join(" ").as_bytes().to_vec();
-                Ok(InternalResourceRecord::CAA {
-                    flag,
-                    tag,
-                    value,
-                    ttl: record.ttl,
-                    rclass: RecordClass::from(&record.rclass),
-                })
-            }
-            RecordType::LOC => {
-                // we do this here because the conversion process is *so* big.
-                let res: FileLocRecord = FileLocRecord::try_from(record.rdata.as_str())?;
-
-                Ok(InternalResourceRecord::LOC {
-                    ttl: record.ttl,
-                    rclass: RecordClass::from(&record.rclass),
-                    version: 0,
-                    size: res.size,
-                    horiz_pre: res.horiz_pre,
-                    vert_pre: res.vert_pre,
-                    latitude: dms_to_u32(res.d1, res.m1, res.s1, res.lat_dir == *"N"),
-                    longitude: dms_to_u32(res.d2, res.m2, res.s2, res.lon_dir == *"E"),
-                    altitude: res.alt,
-                })
-                // Err("LOC not finished!".to_string())
-            }
-            RecordType::URI => {
-                let matches = match URI_RECORD.captures(&record.rdata) {
-                    Some(value) => value,
-                    None => {
-                        return Err(GoatNsError::Generic(
-                            "Failed to parse URL record!".to_string(),
-                        ));
-                    }
-                };
-
-                let priority = match matches.name("priority") {
-                    Some(value) => match value.as_str().parse::<u16>() {
-                        Ok(value) => value,
-                        Err(err) => {
-                            return Err(GoatNsError::Generic(format!(
-                                "Failed to parse priority into u16: {err:?}"
-                            )));
-                        }
-                    },
-                    None => {
-                        return Err(GoatNsError::Generic(
-                            "No target found in record?".to_string(),
-                        ));
-                    }
-                };
-                let weight = match matches.name("weight") {
-                    Some(value) => match value.as_str().parse::<u16>() {
-                        Ok(value) => value,
-                        Err(err) => {
-                            return Err(GoatNsError::Generic(format!(
-                                "Failed to parse weight into u16: {err:?}"
-                            )));
-                        }
-                    },
-                    None => {
-                        return Err(GoatNsError::Generic(
-                            "No target found in record?".to_string(),
-                        ));
-                    }
-                };
-                let target = match matches.name("target") {
-                    Some(value) => DNSCharString::from(value.as_str()),
-                    None => {
-                        return Err(GoatNsError::Generic(
-                            "No target found in record?".to_string(),
-                        ));
-                    }
-                };
-
-                Ok(InternalResourceRecord::URI {
-                    priority,
-                    weight,
-                    target,
-                    ttl: record.ttl,
-                    rclass: RecordClass::from(&record.rclass),
-                })
-            }
-            _ => Err(GoatNsError::Generic("Invalid type specified!".to_string())),
-        }
+        Self::new(&record.name, record.rrtype, &record.rdata, record.ttl, record.rclass)
     }
 }
 
@@ -796,14 +895,22 @@ impl PartialEq<RecordType> for InternalResourceRecord {
             InternalResourceRecord::AAAA { .. } => other == &RecordType::AAAA,
             InternalResourceRecord::AXFR { .. } => other == &RecordType::AXFR,
             InternalResourceRecord::CAA { .. } => other == &RecordType::CAA,
+            InternalResourceRecord::CDNSKEY { .. } => other == &RecordType::CDNSKEY,
+            InternalResourceRecord::CDS { .. } => other == &RecordType::CDS,
             InternalResourceRecord::CNAME { .. } => other == &RecordType::CNAME,
+            InternalResourceRecord::DNSKEY { .. } => other == &RecordType::DNSKEY,
+            InternalResourceRecord::DS { .. } => other == &RecordType::DS,
             InternalResourceRecord::HINFO { .. } => other == &RecordType::HINFO,
             InternalResourceRecord::InvalidType => other == &RecordType::InvalidType,
             InternalResourceRecord::LOC { .. } => other == &RecordType::LOC,
             InternalResourceRecord::MX { .. } => other == &RecordType::MX,
             InternalResourceRecord::NAPTR { .. } => other == &RecordType::NAPTR,
+            InternalResourceRecord::NSEC { .. } => other == &RecordType::NSEC,
+            InternalResourceRecord::NSEC3 { .. } => other == &RecordType::NSEC3,
+            InternalResourceRecord::NSEC3PARAM { .. } => other == &RecordType::NSEC3PARAM,
             InternalResourceRecord::NS { .. } => other == &RecordType::NS,
             InternalResourceRecord::PTR { .. } => other == &RecordType::PTR,
+            InternalResourceRecord::RRSIG { .. } => other == &RecordType::RRSIG,
             InternalResourceRecord::SOA { .. } => other == &RecordType::SOA,
             InternalResourceRecord::TXT { .. } => other == &RecordType::TXT,
             InternalResourceRecord::URI { .. } => other == &RecordType::URI,
@@ -950,6 +1057,135 @@ impl InternalResourceRecord {
                 error!("Asked for an NAPTR as_bytes, returning null");
                 Ok(Vec::new())
             }
+            InternalResourceRecord::DNSKEY {
+                flags,
+                protocol,
+                algorithm,
+                public_key,
+                ..
+            } => {
+                let mut res = vec![];
+                res.extend(flags.to_be_bytes());
+                res.push(*protocol);
+                res.push(*algorithm);
+                res.extend(public_key);
+                Ok(res)
+            }
+            InternalResourceRecord::RRSIG {
+                type_covered,
+                algorithm,
+                labels,
+                original_ttl,
+                signature_expiration,
+                signature_inception,
+                key_tag,
+                signer_name,
+                signature,
+                ..
+            } => {
+                let mut res = vec![];
+                let rrtype: u16 = (*type_covered).into();
+                res.extend(rrtype.to_be_bytes());
+                res.push(*algorithm);
+                res.push(*labels);
+                res.extend(original_ttl.to_be_bytes());
+                res.extend(signature_expiration.to_be_bytes());
+                res.extend(signature_inception.to_be_bytes());
+                res.extend(key_tag.to_be_bytes());
+                let signer_bytes =
+                    signer_name.as_bytes_compressed(Some(HEADER_BYTES as u16), Some(question))?;
+                res.extend::<Vec<u8>>(signer_bytes.into());
+                res.extend(signature);
+                Ok(res)
+            }
+            InternalResourceRecord::NSEC {
+                next_domain_name,
+                type_bit_maps,
+                ..
+            } => {
+                let mut res: Vec<u8> = next_domain_name
+                    .as_bytes_compressed(Some(HEADER_BYTES as u16), Some(question))?
+                    .into();
+                res.extend(type_bit_maps);
+                Ok(res)
+            }
+            InternalResourceRecord::NSEC3 {
+                hash_algorithm,
+                flags,
+                iterations,
+                salt,
+                next_hashed_owner_name,
+                type_bit_maps,
+                ..
+            } => {
+                let mut res = vec![];
+                res.push(*hash_algorithm);
+                res.push(*flags);
+                res.extend(iterations.to_be_bytes());
+                res.push(salt.len() as u8);
+                res.extend(salt);
+                res.push(next_hashed_owner_name.len() as u8);
+                res.extend(next_hashed_owner_name);
+                res.extend(type_bit_maps);
+                Ok(res)
+            }
+            InternalResourceRecord::NSEC3PARAM {
+                hash_algorithm,
+                flags,
+                iterations,
+                salt,
+                ..
+            } => {
+                let mut res = vec![];
+                res.push(*hash_algorithm);
+                res.push(*flags);
+                res.extend(iterations.to_be_bytes());
+                res.push(salt.len() as u8);
+                res.extend(salt);
+                Ok(res)
+            }
+            InternalResourceRecord::DS {
+                key_tag,
+                algorithm,
+                digest_type,
+                digest,
+                ..
+            } => {
+                let mut res = vec![];
+                res.extend(key_tag.to_be_bytes());
+                res.push(*algorithm);
+                res.push(*digest_type);
+                res.extend(digest);
+                Ok(res)
+            }
+            InternalResourceRecord::CDNSKEY {
+                flags,
+                protocol,
+                algorithm,
+                public_key,
+                ..
+            } => {
+                let mut res = vec![];
+                res.extend(flags.to_be_bytes());
+                res.push(*protocol);
+                res.push(*algorithm);
+                res.extend(public_key);
+                Ok(res)
+            }
+            InternalResourceRecord::CDS {
+                key_tag,
+                algorithm,
+                digest_type,
+                digest,
+                ..
+            } => {
+                let mut res = vec![];
+                res.extend(key_tag.to_be_bytes());
+                res.push(*algorithm);
+                res.push(*digest_type);
+                res.extend(digest);
+                Ok(res)
+            }
         }
     }
 
@@ -970,14 +1206,22 @@ impl InternalResourceRecord {
             InternalResourceRecord::AAAA { ttl, .. } => ttl,
             InternalResourceRecord::AXFR { ttl, .. } => ttl,
             InternalResourceRecord::CAA { ttl, .. } => ttl,
+            InternalResourceRecord::CDNSKEY { ttl, .. } => ttl,
+            InternalResourceRecord::CDS { ttl, .. } => ttl,
             InternalResourceRecord::CNAME { ttl, .. } => ttl,
+            InternalResourceRecord::DNSKEY { ttl, .. } => ttl,
+            InternalResourceRecord::DS { ttl, .. } => ttl,
             InternalResourceRecord::LOC { ttl, .. } => ttl,
             InternalResourceRecord::NAPTR { ttl, .. } => ttl,
+            InternalResourceRecord::NSEC { ttl, .. } => ttl,
+            InternalResourceRecord::NSEC3 { ttl, .. } => ttl,
+            InternalResourceRecord::NSEC3PARAM { ttl, .. } => ttl,
             InternalResourceRecord::NS { ttl, .. } => ttl,
             InternalResourceRecord::SOA { minimum, .. } => minimum,
             InternalResourceRecord::PTR { ttl, .. } => ttl,
             InternalResourceRecord::HINFO { ttl, .. } => ttl,
             InternalResourceRecord::MX { ttl, .. } => ttl,
+            InternalResourceRecord::RRSIG { ttl, .. } => ttl,
             InternalResourceRecord::TXT { ttl, .. } => ttl,
             InternalResourceRecord::URI { ttl, .. } => ttl,
             InternalResourceRecord::InvalidType => &0,
@@ -1018,18 +1262,17 @@ impl SetTTL for InternalResourceRecord {
                 tag,
                 value,
                 rclass,
-                ttl,
-            },
-            Self::CNAME { cname, rclass, .. } => Self::CNAME { cname, ttl, rclass },
-            Self::LOC {
-                rclass,
-                version,
-                size,
-                horiz_pre,
-                vert_pre,
-                latitude,
-                longitude,
-                altitude,
+                 ttl,
+             },
+             Self::LOC {
+                 rclass,
+                 version,
+                 size,
+                 horiz_pre,
+                 vert_pre,
+                 latitude,
+                 longitude,
+                 altitude,
                 ..
             } => Self::LOC {
                 ttl,
@@ -1115,6 +1358,137 @@ impl SetTTL for InternalResourceRecord {
                 ttl,
                 rclass,
             },
+            Self::CDNSKEY {
+                flags,
+                protocol,
+                algorithm,
+                public_key,
+                rclass,
+                ..
+            } => Self::CDNSKEY {
+                flags,
+                protocol,
+                algorithm,
+                public_key,
+                rclass,
+                ttl,
+            },
+            Self::CDS {
+                key_tag,
+                algorithm,
+                digest_type,
+                digest,
+                rclass,
+                ..
+            } => Self::CDS {
+                key_tag,
+                algorithm,
+                digest_type,
+                digest,
+                rclass,
+                ttl,
+            },
+            Self::CNAME { cname, rclass, .. } => Self::CNAME { cname, ttl, rclass },
+            Self::DNSKEY {
+                flags,
+                protocol,
+                algorithm,
+                public_key,
+                rclass,
+                ..
+            } => Self::DNSKEY {
+                flags,
+                protocol,
+                algorithm,
+                public_key,
+                rclass,
+                ttl,
+            },
+            Self::DS {
+                key_tag,
+                algorithm,
+                digest_type,
+                digest,
+                rclass,
+                ..
+            } => Self::DS {
+                key_tag,
+                algorithm,
+                digest_type,
+                digest,
+                rclass,
+                ttl,
+            },
+            Self::NSEC {
+                next_domain_name,
+                type_bit_maps,
+                rclass,
+                ..
+            } => Self::NSEC {
+                next_domain_name,
+                type_bit_maps,
+                rclass,
+                ttl,
+            },
+            Self::NSEC3 {
+                hash_algorithm,
+                flags,
+                iterations,
+                salt,
+                next_hashed_owner_name,
+                type_bit_maps,
+                rclass,
+                ..
+            } => Self::NSEC3 {
+                hash_algorithm,
+                flags,
+                iterations,
+                salt,
+                next_hashed_owner_name,
+                type_bit_maps,
+                rclass,
+                ttl,
+            },
+            Self::NSEC3PARAM {
+                hash_algorithm,
+                flags,
+                iterations,
+                salt,
+                rclass,
+                ..
+            } => Self::NSEC3PARAM {
+                hash_algorithm,
+                flags,
+                iterations,
+                salt,
+                rclass,
+                ttl,
+            },
+            Self::RRSIG {
+                type_covered,
+                algorithm,
+                labels,
+                original_ttl,
+                signature_expiration,
+                signature_inception,
+                key_tag,
+                signer_name,
+                signature,
+                rclass,
+                ..
+            } => Self::RRSIG {
+                type_covered,
+                algorithm,
+                labels,
+                original_ttl,
+                signature_expiration,
+                signature_inception,
+                key_tag,
+                signer_name,
+                signature,
+                rclass,
+                ttl,
+            },
             Self::TXT { txtdata, class, .. } => Self::TXT {
                 txtdata,
                 class,
@@ -1153,7 +1527,7 @@ mod tests {
     use crate::enums::RecordType;
     use crate::{RecordClass, db::entities};
 
-    use super::{DNSCharString, InternalResourceRecord};
+    use super::{DNSCharString, DomainName, InternalResourceRecord};
     #[test]
     fn eq_resourcerecord() {
         assert_eq!(
@@ -1225,6 +1599,204 @@ mod tests {
             let foo_bytes: Vec<u8> = txtdata.into();
             assert_eq!(foo_bytes[0], 11);
         };
+    }
+
+    #[test]
+    fn dnssec_dnskey_as_bytes() {
+        let rr = InternalResourceRecord::DNSKEY {
+            flags: 257,
+            protocol: 3,
+            algorithm: 8,
+            public_key: vec![0xde, 0xad, 0xbe, 0xef],
+            ttl: 3600,
+            rclass: RecordClass::Internet,
+        };
+        let empty = Vec::new();
+        let bytes = rr.as_bytes(&empty).expect("DNSKEY as_bytes");
+        assert_eq!(bytes[0..2], [0x01, 0x01]); // flags 257
+        assert_eq!(bytes[2], 3); // protocol
+        assert_eq!(bytes[3], 8); // algorithm
+        assert_eq!(bytes[4..], [0xde, 0xad, 0xbe, 0xef]); // public key
+    }
+
+    #[test]
+    fn dnssec_ds_as_bytes() {
+        let rr = InternalResourceRecord::DS {
+            key_tag: 12345,
+            algorithm: 8,
+            digest_type: 2,
+            digest: vec![0xab, 0xcd, 0xef, 0x01],
+            ttl: 3600,
+            rclass: RecordClass::Internet,
+        };
+        let empty = Vec::new();
+        let bytes = rr.as_bytes(&empty).expect("DS as_bytes");
+        assert_eq!(bytes[0..2], [0x30, 0x39]); // key_tag 12345
+        assert_eq!(bytes[2], 8); // algorithm
+        assert_eq!(bytes[3], 2); // digest_type
+        assert_eq!(bytes[4..], [0xab, 0xcd, 0xef, 0x01]); // digest
+    }
+
+    #[test]
+    fn dnssec_nsec3param_as_bytes() {
+        let rr = InternalResourceRecord::NSEC3PARAM {
+            hash_algorithm: 1,
+            flags: 0,
+            iterations: 10,
+            salt: vec![0xaa, 0xbb],
+            ttl: 3600,
+            rclass: RecordClass::Internet,
+        };
+        let empty = Vec::new();
+        let bytes = rr.as_bytes(&empty).expect("NSEC3PARAM as_bytes");
+        assert_eq!(bytes[0], 1); // hash_algorithm
+        assert_eq!(bytes[1], 0); // flags
+        assert_eq!(bytes[2..4], [0x00, 0x0a]); // iterations 10
+        assert_eq!(bytes[4], 2); // salt length
+        assert_eq!(bytes[5..], [0xaa, 0xbb]); // salt
+    }
+
+    #[test]
+    fn dnssec_rrsig_as_bytes() {
+        let rr = InternalResourceRecord::RRSIG {
+            type_covered: RecordType::A,
+            algorithm: 8,
+            labels: 2,
+            original_ttl: 3600,
+            signature_expiration: 1700000000,
+            signature_inception: 1699999000,
+            key_tag: 54321,
+            signer_name: DomainName::from("example.com"),
+            signature: vec![0xca, 0xfe],
+            ttl: 3600,
+            rclass: RecordClass::Internet,
+        };
+        // use the same name as the signer so it compresses to a pointer (12 = HEADER_BYTES)
+        let question = b"example.com".to_vec();
+        let bytes = rr.as_bytes(&question).expect("RRSIG as_bytes");
+        // type_covered = A = 1
+        assert_eq!(bytes[0..2], [0, 1]);
+        // algorithm
+        assert_eq!(bytes[2], 8);
+        // labels
+        assert_eq!(bytes[3], 2);
+        // original_ttl
+        assert_eq!(bytes[4..8], 3600u32.to_be_bytes());
+        // signature_expiration
+        assert_eq!(bytes[8..12], 1700000000u32.to_be_bytes());
+        // signature_inception
+        assert_eq!(bytes[12..16], 1699999000u32.to_be_bytes());
+        // key_tag
+        assert_eq!(bytes[16..18], 54321u16.to_be_bytes());
+        // signer_name "example.com" compressed to a pointer [0xC0, 0x0C] (offset 12 = HEADER_BYTES)
+        assert_eq!(bytes[18..20], [0xC0, 0x0C]);
+        // signature follows the pointer
+        assert_eq!(bytes[20..], [0xca, 0xfe]);
+    }
+
+    #[test]
+    fn dnssec_dnskey_from_records_model() {
+        let model = entities::records::Model {
+            id: Uuid::nil(),
+            zoneid: Uuid::nil(),
+            name: "@".to_string(),
+            ttl: Some(3600),
+            rclass: RecordClass::Internet as u16,
+            rrtype: RecordType::DNSKEY as u16,
+            rdata: "01010308deadbeef".to_string(),
+        };
+        let rr: InternalResourceRecord = model.try_into().expect("DNSKEY try_from");
+        match rr {
+            InternalResourceRecord::DNSKEY {
+                flags,
+                protocol,
+                algorithm,
+                public_key,
+                ..
+            } => {
+                assert_eq!(flags, 257);
+                assert_eq!(protocol, 3);
+                assert_eq!(algorithm, 8);
+                assert_eq!(public_key, vec![0xde, 0xad, 0xbe, 0xef]);
+            }
+            _ => panic!("Expected DNSKEY variant"),
+        }
+    }
+
+    #[test]
+    fn dnssec_ds_from_records_model() {
+        let model = entities::records::Model {
+            id: Uuid::nil(),
+            zoneid: Uuid::nil(),
+            name: "@".to_string(),
+            ttl: Some(3600),
+            rclass: RecordClass::Internet as u16,
+            rrtype: RecordType::DS as u16,
+            rdata: "30390802abcdef01".to_string(),
+        };
+        let rr: InternalResourceRecord = model.try_into().expect("DS try_from");
+        match rr {
+            InternalResourceRecord::DS {
+                key_tag,
+                algorithm,
+                digest_type,
+                digest,
+                ..
+            } => {
+                assert_eq!(key_tag, 12345);
+                assert_eq!(algorithm, 8);
+                assert_eq!(digest_type, 2);
+                assert_eq!(digest, vec![0xab, 0xcd, 0xef, 0x01]);
+            }
+            _ => panic!("Expected DS variant"),
+        }
+    }
+
+    #[test]
+    fn dnssec_nsec3_from_records_model() {
+        // NSEC3PARAM-like: hash_alg=1, flags=0, iterations=10, salt=[aa,bb]
+        let model = entities::records::Model {
+            id: Uuid::nil(),
+            zoneid: Uuid::nil(),
+            name: "@".to_string(),
+            ttl: Some(3600),
+            rclass: RecordClass::Internet as u16,
+            rrtype: RecordType::NSEC3PARAM as u16,
+            rdata: "0100000a02aabb".to_string(),
+        };
+        let rr: InternalResourceRecord = model.try_into().expect("NSEC3PARAM try_from");
+        match rr {
+            InternalResourceRecord::NSEC3PARAM {
+                hash_algorithm,
+                flags,
+                iterations,
+                salt,
+                ..
+            } => {
+                assert_eq!(hash_algorithm, 1);
+                assert_eq!(flags, 0);
+                assert_eq!(iterations, 10);
+                assert_eq!(salt, vec![0xaa, 0xbb]);
+            }
+            _ => panic!("Expected NSEC3PARAM variant"),
+        }
+    }
+
+    #[test]
+    fn dnssec_nsec_as_bytes() {
+        let rr = InternalResourceRecord::NSEC {
+            next_domain_name: DomainName::from("example.com"),
+            type_bit_maps: vec![0x00, 0x04, 0x00, 0x00, 0x00, 0x00],
+            ttl: 3600,
+            rclass: RecordClass::Internet,
+        };
+        // use the same name as the reference so the next_domain_name compresses to a pointer
+        let question = b"example.com".to_vec();
+        let bytes = rr.as_bytes(&question).expect("NSEC as_bytes");
+        // next_domain_name = "example.com" matches the reference, so it's compressed to [0xC0, 0x0C]
+        assert_eq!(bytes[0..2], [0xC0, 0x0C]);
+        // type_bit_maps follow the pointer
+        assert_eq!(bytes[2..], [0x00, 0x04, 0x00, 0x00, 0x00, 0x00]);
     }
 }
 

--- a/src/servers.rs
+++ b/src/servers.rs
@@ -31,8 +31,8 @@ pub(crate) enum ChaosResult {
 /// this handles a shutdown CHAOS request
 async fn check_for_shutdown(r: &Reply, allowed_shutdown: bool) -> Result<ChaosResult, GoatNsError> {
     // when you get a CHAOS from localhost with "shutdown" break dat loop
-    if let Some(q) = &r.question {
-        if q.qclass == RecordClass::Chaos {
+    if let Some(q) = &r.question
+        && q.qclass == RecordClass::Chaos {
             let qname = from_utf8(&q.qname).inspect_err(|e| {
                 error!(
                     "Failed to parse qname from {:?}, this shouldn't be able to happen! {e:?}",
@@ -59,8 +59,7 @@ async fn check_for_shutdown(r: &Reply, allowed_shutdown: bool) -> Result<ChaosRe
                     }
                 };
             }
-        }
-    };
+        };
 
     let mut chaos_reply = r.clone();
     chaos_reply.answers.push(CHAOS_NO.clone());
@@ -209,11 +208,10 @@ pub async fn tcp_conn_handler(
         };
         trace!("Read {:?} bytes from TCP stream", len);
     }
-    if capture_packets {
-        if let Err(err) = crate::utils::hexdump(&buf) {
+    if capture_packets
+        && let Err(err) = crate::utils::hexdump(&buf) {
             error!("Failed to hexdump buffer: {:?}", err);
         };
-    }
     // the first two bytes of a tcp query is the message length
     // ref <https://www.rfc-editor.org/rfc/rfc7766#section-8>
 

--- a/src/servers.rs
+++ b/src/servers.rs
@@ -5,7 +5,10 @@ use crate::error::GoatNsError;
 use crate::reply::{Reply, reply_any, reply_builder, reply_nxdomain};
 use crate::resourcerecord::{DNSCharString, InternalResourceRecord};
 use crate::zones::ZoneRecord;
-use crate::{HEADER_BYTES, Header, OpCode, Question, REPLY_TIMEOUT_MS, UDP_BUFFER_SIZE};
+use crate::{
+    HEADER_BYTES, Header, OpCode, OptRecord, Question, REPLY_TIMEOUT_MS, UDP_BUFFER_SIZE,
+    parse_opt_from_additional, question_qname_wire_len,
+};
 use concread::cowcell::asynch::CowCellReadTxn;
 use packed_struct::prelude::*;
 use std::io::Error;
@@ -151,7 +154,8 @@ pub async fn udp_server_with_socket(
 
                 let reply_bytes: Vec<u8> = match r.as_bytes().await {
                     Ok(value) => {
-                        // Check if it's too long and set truncate flag if so, it's safe to unwrap since we've already gone
+                        // RFC 7766 §4.1: if the response is too large for UDP, set the TC (truncated) bit
+                        // and send the truncated response. The client will retry over TCP.
                         if value.len() > UDP_BUFFER_SIZE {
                             r = r.check_set_truncated().await;
                             r.as_bytes_udp().await?
@@ -475,6 +479,12 @@ async fn get_result(
         }
     };
 
+    // calculate where the question section ends so we can parse the additional section
+    let qname_len = question_qname_wire_len(&question.qname);
+    let question_end = HEADER_BYTES + qname_len + 4;
+    let (opt_record, do_bit) =
+        parse_opt_from_additional(buf, question_end);
+
     // record the details of the query
     let span = tracing::Span::current();
     if !span.is_disabled() {
@@ -516,6 +526,7 @@ async fn get_result(
         name: question.qname.clone(),
         rrtype: question.qtype,
         rclass: question.qclass,
+        do_bit,
         resp: tx_oneshot,
     };
 
@@ -549,6 +560,19 @@ async fn get_result(
         .filter(|r| r.is_type(RecordType::NS))
         .count() as u16;
 
+    // build EDNS0 OPT RR for the response if the client sent one
+    let additional = if let Some(ref opt) = opt_record {
+        let response_opt = OptRecord::response(
+            UDP_BUFFER_SIZE as u16,
+            opt.dnssec_ok(),
+        );
+        vec![response_opt.to_wire()]
+    } else {
+        vec![]
+    };
+
+    let arcount = additional.len() as u16;
+
     // this is our reply - static until that bit's done
     Ok(Reply {
         header: Header {
@@ -560,19 +584,20 @@ async fn get_result(
             recursion_desired: header.recursion_desired,
             recursion_available: false, // TODO: work this out
             z: false,
-            // TODO: decide how the ad flag should be set
-            ad: false,
-            cd: false, // TODO: figure this out -  CD (checking disabled) bit in the query. This requests the server to not perform DNSSEC validation of responses.
+            // ad (authentic data) bit: set when the zone is DNSSEC-signed
+            ad: record.signed,
+            // copy the CD (checking disabled) bit from the query
+            cd: header.cd,
             rcode: Rcode::NoError,
             qdcount: 1,
             ancount: record.typerecords.len() as u16,
             nscount,
-            arcount: 0,
+            arcount,
         },
         question: Some(question),
         answers: record.typerecords,
         authorities: vec![], // TODO: we're authoritative, we should respond with our records!
-        additional: vec![],
+        additional,
     })
 }
 

--- a/src/tests/dnssec.rs
+++ b/src/tests/dnssec.rs
@@ -1,0 +1,305 @@
+use super::prelude::*;
+
+use crate::zones::ZoneRecord;
+use crate::enums::RecordType;
+use crate::resourcerecord::InternalResourceRecord;
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+async fn setup_signed_zone() -> DatabaseConnection {
+    let dbconn = test_get_sqlite_memory().await;
+
+    let zone = entities::zones::ActiveModel {
+        id: NotSet,
+        name: Set("example.com".to_string()),
+        rname: Set("admin.example.com".to_string()),
+        serial: Set(2024010101),
+        refresh: Set(3600),
+        retry: Set(600),
+        expire: Set(604800),
+        minimum: Set(86400),
+        signed: Set(true),
+    };
+    let zone_model = zone.insert(&dbconn).await.expect("insert zone");
+
+    let _a_record = entities::records::ActiveModel {
+        id: NotSet,
+        zoneid: Set(zone_model.id),
+        name: Set(String::new()),
+        ttl: Set(Some(3600u32)),
+        rrtype: Set(RecordType::A as u16),
+        rclass: Set(RecordClass::Internet as u16),
+        rdata: Set("192.0.2.1".to_string()),
+    }
+    .insert(&dbconn)
+    .await
+    .expect("insert A record");
+
+    let dnskey_rdata = "01010308deadbeef".to_string();
+    let __dnskey = entities::records::ActiveModel {
+        id: NotSet,
+        zoneid: Set(zone_model.id),
+        name: Set(String::new()),
+        ttl: Set(Some(3600u32)),
+        rrtype: Set(RecordType::DNSKEY as u16),
+        rclass: Set(RecordClass::Internet as u16),
+        rdata: Set(dnskey_rdata),
+    }
+    .insert(&dbconn)
+    .await
+    .expect("insert DNSKEY record");
+
+    let rrsig_rdata = format!(
+        "{:04x}080200000e100058f3c90007{:04x}08example.com",
+        RecordType::A as u16,
+        12345u16
+    );
+    let _rrsig = entities::records::ActiveModel {
+        id: NotSet,
+        zoneid: Set(zone_model.id),
+        name: Set(String::new()),
+        ttl: Set(Some(3600u32)),
+        rrtype: Set(RecordType::RRSIG as u16),
+        rclass: Set(RecordClass::Internet as u16),
+        rdata: Set(rrsig_rdata),
+    }
+    .insert(&dbconn)
+    .await
+    .expect("insert RRSIG record");
+
+    dbconn
+}
+
+#[tokio::test]
+async fn dnssec_signed_zone_returns_ad_bit_and_rrsig() {
+    test_logging().await;
+    let dbconn = setup_signed_zone().await;
+
+    let qname = b"example.com".to_vec();
+    let db_name = String::from_utf8(qname.clone()).unwrap();
+    let records = entities::records_merged::Entity::get_records(
+        &dbconn,
+        &db_name,
+        RecordType::A,
+        RecordClass::Internet,
+        true,
+    )
+    .await
+    .expect("get A records");
+
+    assert!(
+        !records.is_empty(),
+        "expected at least one A record for example.com"
+    );
+    let has_a_record = records.iter().any(|r| r.rrtype == RecordType::A as u16);
+    assert!(has_a_record, "expected A record in results");
+
+    let has_dnskey = entities::records_merged::Entity::get_records(
+        &dbconn,
+        &db_name,
+        RecordType::DNSKEY,
+        RecordClass::Internet,
+        true,
+    )
+    .await
+    .expect("get DNSKEY records")
+    .iter()
+    .any(|r| r.rrtype == RecordType::DNSKEY as u16);
+    assert!(has_dnskey, "expected DNSKEY record in results");
+
+    let has_rrsig = entities::records_merged::Entity::get_records(
+        &dbconn,
+        &db_name,
+        RecordType::RRSIG,
+        RecordClass::Internet,
+        true,
+    )
+    .await
+    .expect("get RRSIG records")
+    .iter()
+    .any(|r| r.rrtype == RecordType::RRSIG as u16);
+    assert!(has_rrsig, "expected RRSIG record in results");
+}
+
+#[tokio::test]
+async fn dnssec_signed_zone_ad_bit_in_wire_response() {
+    test_logging().await;
+
+    use crate::reply::Reply;
+    use crate::resourcerecord::InternalResourceRecord;
+    use crate::{Header, PacketType, Question};
+    use packed_struct::prelude::*;
+
+    let dbconn = setup_signed_zone().await;
+
+    let mut zr = ZoneRecord {
+        name: b"example.com".to_vec(),
+        typerecords: vec![],
+        signed: true,
+    };
+
+    let records = entities::records_merged::Entity::get_records(
+        &dbconn,
+        "example.com",
+        RecordType::A,
+        RecordClass::Internet,
+        true,
+    )
+    .await
+    .expect("get A records");
+
+    zr.typerecords = records
+        .into_iter()
+        .filter_map(|r| InternalResourceRecord::try_from(r).ok())
+        .collect();
+
+    assert!(
+        !zr.typerecords.is_empty(),
+        "expected A record in ZoneRecord"
+    );
+
+    let question = Question {
+        qname: b"example.com".to_vec(),
+        qtype: RecordType::A,
+        qclass: RecordClass::Internet,
+    };
+
+    let _ttl = 3600u32;
+    let reply = Reply {
+        header: Header {
+            id: 1234,
+            qr: PacketType::Answer,
+            opcode: crate::OpCode::Query,
+            authoritative: true,
+            truncated: false,
+            recursion_desired: false,
+            recursion_available: false,
+            z: false,
+            ad: zr.signed,
+            cd: false,
+            rcode: crate::Rcode::NoError,
+            qdcount: 1,
+            ancount: zr.typerecords.len() as u16,
+            nscount: 0,
+            arcount: 0,
+        },
+        question: Some(question),
+        answers: zr.typerecords,
+        authorities: vec![],
+        additional: vec![],
+    };
+
+    let reply_bytes = reply.as_bytes().await.expect("serialize reply");
+
+    assert!(reply_bytes.len() > 12, "reply should have content");
+
+    let header = Header::unpack_from_slice(&reply_bytes[..12]).expect("unpack header");
+    assert_eq!(header.ad, true, "AD bit should be set for signed zone");
+    assert_eq!(header.ancount, 1, "ancount should be 1 (A record)");
+
+    drop(dbconn);
+}
+
+#[tokio::test]
+async fn dnssec_unsigned_zone_no_ad_bit() {
+    test_logging().await;
+
+    let dbconn = test_get_sqlite_memory().await;
+
+    let zone = entities::zones::ActiveModel {
+        id: NotSet,
+        name: Set("unsigned.example".to_string()),
+        rname: Set("admin.unsigned.example".to_string()),
+        serial: Set(1u32),
+        refresh: Set(3600),
+        retry: Set(600),
+        expire: Set(604800),
+        minimum: Set(86400),
+        signed: Set(false),
+    };
+    let zone_model = zone.insert(&dbconn).await.expect("insert zone");
+
+    let _a_record = entities::records::ActiveModel {
+        id: NotSet,
+        zoneid: Set(zone_model.id),
+        name: Set(String::new()),
+        ttl: Set(Some(3600u32)),
+        rrtype: Set(RecordType::A as u16),
+        rclass: Set(RecordClass::Internet as u16),
+        rdata: Set("192.0.2.2".to_string()),
+    }
+    .insert(&dbconn)
+    .await
+    .expect("insert A record");
+
+    let zone_check = entities::zones::Entity::find()
+        .filter(entities::zones::Column::Id.eq(zone_model.id))
+        .one(&dbconn)
+        .await
+        .expect("find zone")
+        .expect("zone exists");
+
+    assert_eq!(zone_check.signed, false, "zone should be unsigned");
+
+    let records = entities::records_merged::Entity::get_records(
+        &dbconn,
+        "unsigned.example",
+        RecordType::A,
+        RecordClass::Internet,
+        true,
+    )
+    .await
+    .expect("get A records");
+
+    assert!(!records.is_empty(), "should have A record");
+
+    let has_dnskey = entities::records_merged::Entity::get_records(
+        &dbconn,
+        "unsigned.example",
+        RecordType::DNSKEY,
+        RecordClass::Internet,
+        true,
+    )
+    .await
+    .expect("get DNSKEY records");
+    assert!(
+        has_dnskey.is_empty(),
+        "unsigned zone should have no DNSKEY record"
+    );
+
+    let zr = ZoneRecord {
+        name: b"unsigned.example".to_vec(),
+        typerecords: records
+            .into_iter()
+            .filter_map(|r| InternalResourceRecord::try_from(r).ok())
+            .collect(),
+        signed: false,
+    };
+
+    assert_eq!(zr.signed, false);
+
+    drop(dbconn);
+}
+
+#[tokio::test]
+async fn dnssec_do_bit_triggers_rrsig_lookup() {
+    test_logging().await;
+    let dbconn = setup_signed_zone().await;
+
+    let records_with_do = entities::records_merged::Entity::get_records(
+        &dbconn,
+        "example.com",
+        RecordType::RRSIG,
+        RecordClass::Internet,
+        true,
+    )
+    .await
+    .expect("get RRSIG records");
+
+    let rrsig_count = records_with_do
+        .iter()
+        .filter(|r| r.rrtype == RecordType::RRSIG as u16)
+        .count();
+    assert!(rrsig_count > 0, "should find RRSIG records for signed zone");
+
+    drop(dbconn);
+}

--- a/src/tests/dnssec.rs
+++ b/src/tests/dnssec.rs
@@ -1,8 +1,8 @@
 use super::prelude::*;
 
-use crate::zones::ZoneRecord;
 use crate::enums::RecordType;
 use crate::resourcerecord::InternalResourceRecord;
+use crate::zones::ZoneRecord;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 
 async fn setup_signed_zone() -> DatabaseConnection {
@@ -75,7 +75,7 @@ async fn dnssec_signed_zone_returns_ad_bit_and_rrsig() {
     let dbconn = setup_signed_zone().await;
 
     let qname = b"example.com".to_vec();
-    let db_name = String::from_utf8(qname.clone()).unwrap();
+    let db_name = String::from_utf8(qname.clone()).expect("invalid UTF-8");
     let records = entities::records_merged::Entity::get_records(
         &dbconn,
         &db_name,
@@ -193,7 +193,7 @@ async fn dnssec_signed_zone_ad_bit_in_wire_response() {
     assert!(reply_bytes.len() > 12, "reply should have content");
 
     let header = Header::unpack_from_slice(&reply_bytes[..12]).expect("unpack header");
-    assert_eq!(header.ad, true, "AD bit should be set for signed zone");
+    assert!(header.ad, "AD bit should be set for signed zone");
     assert_eq!(header.ancount, 1, "ancount should be 1 (A record)");
 
     drop(dbconn);
@@ -238,7 +238,7 @@ async fn dnssec_unsigned_zone_no_ad_bit() {
         .expect("find zone")
         .expect("zone exists");
 
-    assert_eq!(zone_check.signed, false, "zone should be unsigned");
+    assert!(!zone_check.signed, "zone should be unsigned");
 
     let records = entities::records_merged::Entity::get_records(
         &dbconn,
@@ -275,7 +275,7 @@ async fn dnssec_unsigned_zone_no_ad_bit() {
         signed: false,
     };
 
-    assert_eq!(zr.signed, false);
+    assert!(!zr.signed);
 
     drop(dbconn);
 }

--- a/src/tests/e2e_test.rs
+++ b/src/tests/e2e_test.rs
@@ -112,6 +112,17 @@ mod tests {
         let status_url = config.read().await.status_url();
         wait_for_server(status_url).await;
 
+        use crate::datastore::import_zonefile;
+
+        let zone_file = crate::zones::load_zones("./examples/test_config/zones.json")
+            .expect("Failed to load zones.json")
+            .into_iter()
+            .next()
+            .expect("Expected at least one zone");
+        import_zonefile(&connpool, zone_file)
+            .await
+            .expect("Failed to import test zone file");
+
         // Construct a new Resolver pointing at localhost
         let mut resolver_config = ResolverConfig::new();
         resolver_config.add_name_server(NameServerConfig::new(dns_addr, Protocol::Udp));
@@ -167,6 +178,134 @@ mod tests {
         };
         assert!(!response.records().is_empty());
         eprintln!("URL response: {response:?}");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dnssec_signed_zone() -> Result<(), std::io::Error> {
+        test_logging().await;
+        crate::init_crypto();
+
+        if in_github_actions() {
+            eprintln!("Skipping DNSSEC test because it won't work in GHA");
+            return Ok(());
+        }
+
+        let config = crate::config::ConfigFile::try_as_cowcell(Some(PathBuf::from(
+            "./examples/test_config/goatns-test.json",
+        )))?;
+
+        let db_path = tempfile::tempdir()?;
+        let mut cw = config.write().await;
+        let udp_socket = tokio::net::UdpSocket::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("failed to bind test UDP listener");
+        let dns_addr = udp_socket
+            .local_addr()
+            .expect("failed to inspect test UDP listener");
+        let api_listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .expect("failed to bind test API listener");
+        let api_addr = api_listener
+            .local_addr()
+            .expect("failed to inspect test API listener");
+        api_listener
+            .set_nonblocking(true)
+            .expect("failed to set test API listener nonblocking");
+
+        cw.db_path = db_path
+            .path()
+            .with_file_name("goatns-test-dnssec.db")
+            .display()
+            .to_string();
+        cw.port = dns_addr.port();
+        cw.api_port = api_addr.port();
+        cw.commit().await;
+
+        let (agent_sender, datastore_tx, datastore_rx) = crate::utils::start_channels();
+
+        let udpserver = tokio::spawn(crate::servers::udp_server_with_socket(
+            config.read().await,
+            datastore_tx.clone(),
+            agent_sender.clone(),
+            udp_socket,
+        ));
+
+        let connpool = crate::db::get_conn(config.read().await)
+            .await
+            .expect("Failed to get connpool");
+
+        let datastore_manager = tokio::spawn(crate::datastore::manager(
+            datastore_rx,
+            "hello.goat".to_string(),
+            connpool.clone(),
+            None,
+        ));
+
+        let (_apiserver_tx, apiserver_rx) = tokio::sync::mpsc::channel(5);
+        let apiserver = crate::web::build_with_listener(
+            datastore_tx.clone(),
+            apiserver_rx,
+            config.read().await,
+            connpool.clone(),
+            api_listener,
+        )
+        .await
+        .expect("Failed to build API server");
+
+        let _ = crate::servers::Servers::build(agent_sender)
+            .with_datastore(datastore_manager)
+            .with_udpserver(udpserver)
+            .with_apiserver(apiserver);
+
+        let status_url = config.read().await.status_url();
+        wait_for_server(status_url).await;
+
+        use crate::datastore::import_zonefile;
+        use crate::zones::ZoneFile;
+
+        let zone_files: Vec<ZoneFile> =
+            serde_json::from_str(include_str!("../../examples/test_config/zones.json"))
+                .expect("Failed to parse zones.json");
+
+        let mut zone_file = zone_files
+            .into_iter()
+            .next()
+            .expect("Expected at least one zone in zones.json");
+
+        zone_file.zone.signed = true;
+
+        import_zonefile(&connpool, zone_file)
+            .await
+            .expect("Failed to import DNSSEC test zone");
+
+        let mut resolver_config = ResolverConfig::new();
+        resolver_config.add_name_server(NameServerConfig::new(dns_addr, Protocol::Udp));
+
+        let mut opts = ResolverOpts::default();
+        opts.edns0 = true;
+
+        let resolver = Resolver::builder_with_config(
+            resolver_config,
+            TokioConnectionProvider::default(),
+        )
+        .with_options(opts)
+        .build();
+
+        let response = resolver
+            .lookup_ip("hello.goat")
+            .await
+            .expect("DNSSEC lookup failed");
+
+        let address = response
+            .iter()
+            .next()
+            .expect("no addresses returned");
+        assert_eq!(
+            address,
+            IpAddr::V4(Ipv4Addr::new(6, 6, 6, 6)),
+            "DNSSEC query should return the correct A record"
+        );
 
         Ok(())
     }

--- a/src/tests/e2e_test.rs
+++ b/src/tests/e2e_test.rs
@@ -6,6 +6,7 @@ mod tests {
     use hickory_resolver::{Resolver, config::*};
     use std::env;
     use std::net::*;
+    use std::path::PathBuf;
     use tracing::info;
 
     use crate::enums::RecordType;
@@ -26,9 +27,9 @@ mod tests {
             return Ok(());
         }
 
-        let config = crate::config::ConfigFile::try_as_cowcell(Some(
-            "./examples/test_config/goatns-test.json".to_string(),
-        ))?;
+        let config = crate::config::ConfigFile::try_as_cowcell(Some(PathBuf::from(
+            "./examples/test_config/goatns-test.json",
+        )))?;
 
         println!("Config as loaded: {:?}", config.read().await);
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod config;
 mod db;
+mod dnssec;
 mod doh;
 mod e2e_test;
 mod enums;
@@ -25,6 +26,87 @@ use packed_struct::prelude::*;
 use std::net::IpAddr;
 use std::str::FromStr;
 use tracing::{debug, error, info, trace, warn};
+
+#[test]
+fn opt_record_roundtrip() {
+    use crate::OptRecord;
+    let opt = OptRecord::response(1232, true);
+    let wire = opt.to_wire();
+    let (parsed, consumed) =
+        OptRecord::from_wire(&wire).expect("OPT from_wire should succeed");
+    assert_eq!(consumed, wire.len());
+    assert_eq!(parsed.udp_payload_size, 1232);
+    assert!(parsed.do_bit);
+    assert_eq!(parsed.version, 0);
+    assert_eq!(parsed.extended_rcode, 0);
+}
+
+#[test]
+fn opt_record_without_do_bit() {
+    use crate::OptRecord;
+    let opt = OptRecord::response(512, false);
+    let wire = opt.to_wire();
+    let (parsed, _) =
+        OptRecord::from_wire(&wire).expect("OPT from_wire should succeed");
+    assert_eq!(parsed.udp_payload_size, 512);
+    assert!(!parsed.do_bit);
+}
+
+#[test]
+fn opt_from_additional_with_opt_rr() {
+    use crate::parse_opt_from_additional;
+    let mut buf: Vec<u8> = vec![];
+    buf.extend(0x0001u16.to_be_bytes()); // id
+    buf.extend(0x0000u16.to_be_bytes()); // flags
+    buf.extend(0x0001u16.to_be_bytes()); // qdcount
+    buf.extend(0x0000u16.to_be_bytes()); // ancount
+    buf.extend(0x0000u16.to_be_bytes()); // nscount
+    buf.extend(0x0001u16.to_be_bytes()); // arcount
+    buf.extend(b"\x07example\x03com\x00"); // qname
+    buf.extend(0x0001u16.to_be_bytes()); // qtype A
+    buf.extend(0x0001u16.to_be_bytes()); // qclass IN
+    let opt = crate::OptRecord::response(1232, true);
+    buf.extend(opt.to_wire());
+
+    let question_end = 12 + 13 + 4; // header + qname wire + qtype + qclass
+    let (opt_out, do_bit) = parse_opt_from_additional(&buf, question_end);
+    assert!(opt_out.is_some());
+    assert!(do_bit);
+}
+
+#[test]
+fn opt_from_additional_without_opt() {
+    use crate::parse_opt_from_additional;
+    let mut buf: Vec<u8> = vec![];
+    buf.extend(0x0001u16.to_be_bytes()); // id
+    buf.extend(0x0000u16.to_be_bytes()); // flags
+    buf.extend(0x0001u16.to_be_bytes()); // qdcount
+    buf.extend(0x0000u16.to_be_bytes()); // ancount
+    buf.extend(0x0000u16.to_be_bytes()); // nscount
+    buf.extend(0x0000u16.to_be_bytes()); // arcount
+    buf.extend(b"\x07example\x03com\x00"); // qname
+    buf.extend(0x0001u16.to_be_bytes()); // qtype A
+    buf.extend(0x0001u16.to_be_bytes()); // qclass IN
+
+    let question_end = 12 + 13 + 4;
+    let (opt_out, do_bit) = parse_opt_from_additional(&buf, question_end);
+    assert!(opt_out.is_none());
+    assert!(!do_bit);
+}
+
+#[test]
+fn question_qname_wire_len_example_com() {
+    use crate::question_qname_wire_len;
+    let qname = b"example.com".to_vec();
+    assert_eq!(question_qname_wire_len(&qname), 17);
+}
+
+#[test]
+fn question_qname_wire_len_root() {
+    use crate::question_qname_wire_len;
+    let qname = b"".to_vec();
+    assert_eq!(question_qname_wire_len(&qname), 5);
+}
 
 #[test]
 /// test my assumptions about ipnet things

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -9,6 +9,7 @@ mod resourcerecord;
 mod test_api;
 pub mod test_harness;
 mod utils;
+mod zones;
 
 use crate::db::*;
 use prelude::*;

--- a/src/tests/test_api.rs
+++ b/src/tests/test_api.rs
@@ -1065,3 +1065,95 @@ async fn api_record_delete_does_not_delete_zone() -> Result<(), GoatNsError> {
     drop(pool);
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn admin_middleware_blocks_non_admin_user() -> Result<(), GoatNsError> {
+    let (pool, _servers, config, ..) = start_test_server().await;
+    let api_port = config.read().await.api_port;
+
+    // Create a non-admin user
+    let user = entities::users::ActiveModel {
+        id: NotSet,
+        displayname: Set("Regular user".to_string()),
+        username: Set("regularuser".to_string()),
+        email: Set("regular@hello.goat".to_string()),
+        disabled: Set(false),
+        authref: Set(None),
+        admin: Set(false),
+    }
+    .insert(&pool)
+    .await?;
+
+    let (token, token_secret) = insert_test_user_api_token(&pool, user.id).await?;
+
+    let client = reqwest::ClientBuilder::new()
+        .danger_accept_invalid_certs(true)
+        .cookie_store(true)
+        .timeout(std::time::Duration::from_secs(5))
+        .build()?;
+
+    // Log in as the non-admin user
+    let res = client
+        .post(format!("https://localhost:{api_port}/api/login"))
+        .json(&AuthPayload {
+            token_key: token.key,
+            token_secret,
+        })
+        .send()
+        .await?;
+    assert_eq!(res.status(), 200);
+
+    // Attempt to access admin endpoint — should be 403 FORBIDDEN
+    let res = client
+        .get(format!("https://localhost:{api_port}/ui/admin"))
+        .send()
+        .await?;
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+
+    // Attempt to access admin reports — should be 403 FORBIDDEN
+    let res = client
+        .get(format!("https://localhost:{api_port}/ui/admin/reports/unowned_records"))
+        .send()
+        .await?;
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+
+    drop(pool);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn admin_middleware_allows_admin_user() -> Result<(), GoatNsError> {
+    let (pool, _servers, config, ..) = start_test_server().await;
+    let api_port = config.read().await.api_port;
+
+    // The default test user is admin (admin: Set(true))
+    let user = insert_test_user(&pool).await;
+    let (token, token_secret) = insert_test_user_api_token(&pool, user.id).await?;
+
+    let client = reqwest::ClientBuilder::new()
+        .danger_accept_invalid_certs(true)
+        .cookie_store(true)
+        .timeout(std::time::Duration::from_secs(5))
+        .build()?;
+
+    // Log in as admin
+    let res = client
+        .post(format!("https://localhost:{api_port}/api/login"))
+        .json(&AuthPayload {
+            token_key: token.key,
+            token_secret,
+        })
+        .send()
+        .await?;
+    assert_eq!(res.status(), 200);
+
+    // Access admin endpoint — should be 200 OK
+    let res = client
+        .get(format!("https://localhost:{api_port}/ui/admin"))
+        .send()
+        .await?;
+    assert_eq!(res.status(), StatusCode::OK);
+
+    drop(pool);
+    Ok(())
+}

--- a/src/tests/test_api.rs
+++ b/src/tests/test_api.rs
@@ -12,6 +12,7 @@ use log::info;
 use reqwest::StatusCode;
 use sea_orm::EntityTrait;
 use std::net::{Ipv4Addr, SocketAddr};
+use std::path::PathBuf;
 use tokio::net::{TcpListener, UdpSocket};
 use utoipa::OpenApi;
 
@@ -41,9 +42,9 @@ pub async fn start_test_server() -> (
     test_logging().await;
     let dbconn = test_get_sqlite_memory().await;
 
-    let config = crate::config::ConfigFile::try_as_cowcell(Some(
-        "./examples/test_config/goatns-test.json".to_string(),
-    ))
+    let config = crate::config::ConfigFile::try_as_cowcell(Some(PathBuf::from(
+        "./examples/test_config/goatns-test.json",
+    )))
     .expect("failed to parse test config");
 
     let api_listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
@@ -1112,7 +1113,9 @@ async fn admin_middleware_blocks_non_admin_user() -> Result<(), GoatNsError> {
 
     // Attempt to access admin reports — should be 403 FORBIDDEN
     let res = client
-        .get(format!("https://localhost:{api_port}/ui/admin/reports/unowned_records"))
+        .get(format!(
+            "https://localhost:{api_port}/ui/admin/reports/unowned_records"
+        ))
         .send()
         .await?;
     assert_eq!(res.status(), StatusCode::FORBIDDEN);
@@ -1155,5 +1158,48 @@ async fn admin_middleware_allows_admin_user() -> Result<(), GoatNsError> {
     assert_eq!(res.status(), StatusCode::OK);
 
     drop(pool);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn api_rate_limit_returns_429_after_burst() -> Result<(), GoatNsError> {
+    let (_pool, _servers, config, ..) = start_test_server().await;
+    let api_port = config.read().await.api_port;
+
+    let client = reqwest::ClientBuilder::new()
+        .danger_accept_invalid_certs(true)
+        .timeout(std::time::Duration::from_secs(5))
+        .build()?;
+
+    let url = format!("https://localhost:{api_port}/api/login");
+
+    let mut too_many = 0;
+    let mut ok = 0;
+    for _ in 0..200 {
+        let res = client
+            .post(&url)
+            .json(&AuthPayload {
+                token_key: "x".to_string(),
+                token_secret: "y".to_string(),
+            })
+            .send()
+            .await?;
+        match res.status() {
+            StatusCode::OK | StatusCode::UNAUTHORIZED | StatusCode::INTERNAL_SERVER_ERROR => {
+                ok += 1;
+            }
+            StatusCode::TOO_MANY_REQUESTS => {
+                too_many += 1;
+            }
+            other => panic!("unexpected status: {other}"),
+        }
+    }
+
+    assert!(ok >= 10, "expected at least 10 ok responses, got {ok}");
+    assert!(
+        too_many > 0,
+        "expected some 429 responses after burst, got {too_many}"
+    );
+
     Ok(())
 }

--- a/src/tests/test_api.rs
+++ b/src/tests/test_api.rs
@@ -190,6 +190,7 @@ async fn api_zone_create() -> Result<(), GoatNsError> {
         minimum: 1235,
         refresh: 1234,
         retry: 1234,
+        signed: false,
     };
 
     println!("api_zone_create Sending zone create");
@@ -364,6 +365,7 @@ async fn api_zone_create_delete() -> Result<(), sqlx::Error> {
         minimum: 1235,
         refresh: 1111,
         retry: 1234234,
+        signed: false,
     };
 
     println!("Sending zone create");
@@ -448,6 +450,7 @@ async fn api_zone_create_update() -> Result<(), GoatNsError> {
         minimum: Set(1235),
         refresh: Set(1111),
         retry: Set(1234234),
+        signed: Set(false),
     };
     println!("Saving zone");
     let newzone = newzone.insert(&pool).await?;
@@ -525,6 +528,7 @@ async fn api_record_create() -> Result<(), GoatNsError> {
         minimum: Set(1235),
         refresh: Set(1341234),
         retry: Set(123456),
+        signed: Set(false),
     }
     .insert(&pool)
     .await
@@ -623,6 +627,7 @@ async fn api_record_delete() -> Result<(), GoatNsError> {
         minimum: Set(1235),
         refresh: Set(0),
         retry: Set(0),
+        signed: Set(false),
     }
     .insert(&pool)
     .await
@@ -698,6 +703,7 @@ async fn api_record_delete_forbidden_without_ownership() -> Result<(), GoatNsErr
         minimum: Set(1235),
         refresh: Set(0),
         retry: Set(0),
+        signed: Set(false),
     }
     .insert(&pool)
     .await
@@ -788,6 +794,7 @@ async fn api_record_get_forbidden_without_ownership() -> Result<(), GoatNsError>
         minimum: Set(1235),
         refresh: Set(0),
         retry: Set(0),
+        signed: Set(false),
     }
     .insert(&pool)
     .await
@@ -865,6 +872,7 @@ async fn api_record_get_requires_auth() -> Result<(), GoatNsError> {
         minimum: Set(1235),
         refresh: Set(0),
         retry: Set(0),
+        signed: Set(false),
     }
     .insert(&pool)
     .await
@@ -929,6 +937,7 @@ async fn api_record_delete_requires_auth() -> Result<(), GoatNsError> {
         minimum: Set(1235),
         refresh: Set(0),
         retry: Set(0),
+        signed: Set(false),
     }
     .insert(&pool)
     .await
@@ -1001,6 +1010,7 @@ async fn api_record_delete_does_not_delete_zone() -> Result<(), GoatNsError> {
         minimum: Set(1235),
         refresh: Set(0),
         retry: Set(0),
+        signed: Set(false),
     }
     .insert(&pool)
     .await

--- a/src/tests/zones.rs
+++ b/src/tests/zones.rs
@@ -1,0 +1,87 @@
+use crate::error::GoatNsError;
+use crate::zones::load_zones;
+use crate::zones::MAX_ZONE_FILE_SIZE;
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+fn make_zone_json(name: &str, record_count: usize) -> String {
+    let mut records = String::new();
+    for i in 0..record_count {
+        if i > 0 {
+            records.push(',');
+        }
+        records.push_str(&format!(
+            r#"{{"name":"rec{i}","rrtype":"A","rdata":"10.0.0.{i}","ttl":300}}"#
+        ));
+    }
+    format!(
+        r#"{{"name":"{name}","rname":"admin@{name}","serial":1,"refresh":3600,"retry":600,"expire":86400,"minimum":60,"records":[{records}]}}"#
+    )
+}
+
+fn write_zone_file(entries: usize, record_count: usize) -> NamedTempFile {
+    let mut file = NamedTempFile::new().expect("Failed to create temp file");
+    write!(file, "[").expect("Failed to write");
+    for i in 0..entries {
+        if i > 0 {
+            write!(file, ",").expect("Failed to write");
+        }
+        write!(file, "{}", make_zone_json(&format!("zone{i}.goat"), record_count))
+            .expect("Failed to write");
+    }
+    write!(file, "]").expect("Failed to write");
+    file.flush().expect("Failed to flush");
+    file
+}
+
+#[test]
+fn test_small_zone_file() {
+    let file = write_zone_file(2, 3);
+    let result = load_zones(file.path().to_str().expect("Path to string"));
+    assert!(result.is_ok(), "Expected Ok, got: {result:?}");
+    let zones = result.expect("zones");
+    assert_eq!(zones.len(), 2);
+    assert_eq!(zones[0].records.len(), 3);
+}
+
+#[test]
+fn test_streaming_zone_file() {
+    let entry_size = make_zone_json("zone0.goat", 100).len() as u64;
+    let entries_needed = (MAX_ZONE_FILE_SIZE / entry_size) + 2;
+
+    let file = write_zone_file(entries_needed as usize, 100);
+    let file_size = file.path().metadata().expect("metadata").len();
+    assert!(
+        file_size > MAX_ZONE_FILE_SIZE,
+        "Test file should exceed MAX_ZONE_FILE_SIZE, was {file_size}"
+    );
+
+    let result = load_zones(file.path().to_str().expect("Path to string"));
+    assert!(result.is_ok(), "Expected Ok for streaming parse, got: {result:?}");
+    let zones = result.expect("zones");
+    assert_eq!(zones.len(), entries_needed as usize);
+}
+
+#[test]
+fn test_streaming_invalid_json() {
+    let mut file = NamedTempFile::new().expect("Failed to create temp file");
+    let entry_size = make_zone_json("zone0.goat", 100).len() as u64;
+    let entries_needed = (MAX_ZONE_FILE_SIZE / entry_size) + 2;
+
+    write!(file, "[").expect("Failed to write");
+    for i in 0..entries_needed {
+        if i > 0 {
+            write!(file, ",").expect("Failed to write");
+        }
+        write!(file, "{}", make_zone_json(&format!("zone{i}.goat"), 100))
+            .expect("Failed to write");
+    }
+    write!(file, ",{{invalid}}]").expect("Failed to write");
+    file.flush().expect("Failed to flush");
+
+    let result = load_zones(file.path().to_str().expect("Path to string"));
+    assert!(
+        matches!(result, Err(GoatNsError::FileError(ref msg)) if msg.contains("streaming mode")),
+        "Expected FileError with 'streaming mode', got: {result:?}"
+    );
+}

--- a/src/web/api/auth.rs
+++ b/src/web/api/auth.rs
@@ -45,9 +45,9 @@ pub async fn api_token_login(
     payload: Json<AuthPayload>,
 ) -> Result<(StatusCode, Json<AuthResponse>), (StatusCode, Json<AuthResponse>)> {
     #[cfg(test)]
-    println!("Got login payload: {payload:?}");
+    println!("Got login payload: token_key={}", payload.token_key);
     #[cfg(not(test))]
-    debug!("Got login payload: {payload:?}");
+    debug!("Got login payload: token_key={}", payload.token_key);
     let txn = state.get_db_txn().await.map_err(|err| {
         error!("Failed to get DB transaction: {err:?}");
         (
@@ -106,7 +106,7 @@ pub async fn api_token_login(
 
     match validate_api_token(&token, &payload.token_secret) {
         Ok(_) => {
-            println!("Successfully validated token on login");
+            info!("Successfully validated token on login for user {}", user.username);
             let session_user = session.insert(SESSION_USER_KEY, &user).await;
 
             if session_user.is_err() {

--- a/src/web/api/records.rs
+++ b/src/web/api/records.rs
@@ -36,8 +36,8 @@ impl ZoneFileRecord {
         };
 
         let name = match &self.name {
-            Some(name) => Set(name.clone()),
-            None => Set(String::from("@")),
+            Some(name) if name != "@" => Set(name.clone()),
+            _ => Set(String::new()),
         };
         entities::records::ActiveModel {
             id,

--- a/src/web/api/records.rs
+++ b/src/web/api/records.rs
@@ -132,14 +132,13 @@ pub(crate) async fn api_record_create(
                     }
                 }
                 crate::error::GoatNsError::SqlxError(sqlx::Error::Database(db_err)) => {
-                    if let Some(constraint) = db_err.constraint() {
-                        if constraint == "ind_records" {
+                    if let Some(constraint) = db_err.constraint()
+                        && constraint == "ind_records" {
                             return Err(error_result_json(
                                 "A record with the same name, type, and class already exists in this zone",
                                 StatusCode::CONFLICT,
                             ));
                         }
-                    }
                     // Check for unique constraint error codes
                     if db_err.code() == Some(std::borrow::Cow::Borrowed("2067"))
                         || db_err.code() == Some(std::borrow::Cow::Borrowed("1555"))

--- a/src/web/api/zones.rs
+++ b/src/web/api/zones.rs
@@ -227,12 +227,11 @@ pub(crate) async fn api_zone_update(
         .one(&txn)
         .await
         .map_err(|err| {
-            // TODO: make this a better log
-            println!("Failed to validate user owns zone: {err:?}");
+            error!("Failed to validate user owns zone: {err:?}");
             (
                 StatusCode::UNAUTHORIZED,
                 Json(ErrorResult {
-                    message: "".to_string(),
+                    message: "You do not own this zone".to_string(),
                 }),
             )
         })?
@@ -245,7 +244,7 @@ pub(crate) async fn api_zone_update(
             }),
         ));
     };
-    println!("looks like user owns zone");
+    debug!("User {} owns zone {}, proceeding with update", user.id, zone_form.id);
 
     // save the zone data
 
@@ -271,7 +270,7 @@ pub(crate) async fn api_zone_update(
     }
 
     if zone.is_changed() {
-        println!("Zone has changes, updating...");
+        debug!("Zone has changes, updating...");
         if let Err(err) = zone.update(&txn).await {
             error!("Failed to save zone: {err:?}");
             return Err((

--- a/src/web/api/zones.rs
+++ b/src/web/api/zones.rs
@@ -26,6 +26,8 @@ pub struct ZoneForm {
     pub retry: u32,
     pub expire: u32,
     pub minimum: u32,
+    #[serde(default)]
+    pub signed: bool,
 }
 
 impl From<entities::zones::Model> for ZoneForm {
@@ -39,6 +41,7 @@ impl From<entities::zones::Model> for ZoneForm {
             retry: zone.retry,
             expire: zone.expire,
             minimum: zone.minimum,
+            signed: zone.signed,
         }
     }
 }

--- a/src/web/auth/mod.rs
+++ b/src/web/auth/mod.rs
@@ -266,11 +266,10 @@ pub async fn login(
     State(mut state): State<GoatState>,
 ) -> Result<impl IntoResponse, impl IntoResponse> {
     // check if we've got an existing, valid session
-    if let Some(signed_in) = session.get("signed_in").await.unwrap_or(Some(false)) {
-        if signed_in {
+    if let Some(signed_in) = session.get("signed_in").await.unwrap_or(Some(false))
+        && signed_in {
             return Ok(Urls::ZonesList.redirect().into_response());
         }
-    }
 
     let (query_state, query_code) = match (query.state, query.code) {
         (Some(state), Some(code)) => (state, code),

--- a/src/web/auth/traits.rs
+++ b/src/web/auth/traits.rs
@@ -25,11 +25,10 @@ impl CustomClaimTypeThings for CustomClaimType {
     }
     fn get_displayname(&self) -> String {
         let mut displayname: String = "Anonymous Kid".to_string();
-        if let Some(name) = self.name() {
-            if let Some(username) = name.iter().next() {
+        if let Some(name) = self.name()
+            && let Some(username) = name.iter().next() {
                 displayname = username.1.to_string();
             }
-        }
         displayname
     }
     fn get_username(&self) -> String {

--- a/src/web/middleware/admin.rs
+++ b/src/web/middleware/admin.rs
@@ -1,0 +1,47 @@
+use crate::db::entities;
+use crate::web::constants::SESSION_USER_KEY;
+use crate::web::utils::Urls;
+use axum::http::StatusCode;
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use tower_sessions::Session;
+use tracing::debug;
+
+pub async fn require_admin(
+    session: Session,
+    req: axum::extract::Request,
+    next: Next,
+) -> Response {
+    let user: Option<entities::users::Model> = match session.get(SESSION_USER_KEY).await {
+        Ok(u) => u,
+        Err(err) => {
+            debug!("Session read error in admin middleware: {err:?}");
+            return StatusCode::UNAUTHORIZED.into_response();
+        }
+    };
+
+    let user = match user {
+        Some(u) => u,
+        None => {
+            debug!("No session user in admin middleware");
+            session.clear().await;
+            return StatusCode::UNAUTHORIZED.into_response();
+        }
+    };
+
+    if user.disabled {
+        debug!("Disabled user {} attempted to access admin", user.id);
+        session.clear().await;
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+
+    if !user.admin {
+        debug!(
+            "Non-admin user {} attempted to access admin area, denying",
+            user.id
+        );
+        return StatusCode::FORBIDDEN.into_response();
+    }
+
+    next.run(req).await.into_response()
+}

--- a/src/web/middleware/admin.rs
+++ b/src/web/middleware/admin.rs
@@ -1,6 +1,5 @@
 use crate::db::entities;
 use crate::web::constants::SESSION_USER_KEY;
-use crate::web::utils::Urls;
 use axum::http::StatusCode;
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};

--- a/src/web/middleware/mod.rs
+++ b/src/web/middleware/mod.rs
@@ -1,2 +1,3 @@
 pub mod admin;
 pub mod csp;
+pub mod rate_limit;

--- a/src/web/middleware/mod.rs
+++ b/src/web/middleware/mod.rs
@@ -1,1 +1,2 @@
+pub mod admin;
 pub mod csp;

--- a/src/web/middleware/rate_limit.rs
+++ b/src/web/middleware/rate_limit.rs
@@ -1,0 +1,107 @@
+use axum::extract::ConnectInfo;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use governor::clock::DefaultClock;
+use governor::middleware::NoOpMiddleware;
+use governor::state::keyed::DefaultKeyedStateStore;
+use governor::{Quota, RateLimiter};
+use nonzero_ext::nonzero;
+use std::net::IpAddr;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+const PER_SECOND: u32 = 100;
+const BURST: u32 = 10;
+
+#[derive(Clone)]
+pub struct RateLimitState {
+    limiter: Arc<RateLimiter<IpAddr, DefaultKeyedStateStore<IpAddr>, DefaultClock, NoOpMiddleware>>,
+}
+
+impl Default for RateLimitState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RateLimitState {
+    pub fn new() -> Self {
+        let quota = Quota::per_second(nonzero!(PER_SECOND)).allow_burst(nonzero!(BURST));
+        let limiter = RateLimiter::keyed(quota);
+        Self {
+            limiter: Arc::new(limiter),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct RateLimited;
+
+impl IntoResponse for RateLimited {
+    fn into_response(self) -> Response {
+        (StatusCode::TOO_MANY_REQUESTS, "rate limit exceeded").into_response()
+    }
+}
+
+fn peer_ip(addr: &SocketAddr) -> IpAddr {
+    addr.ip()
+}
+
+pub async fn rate_limit_middleware(
+    State(gs): State<crate::web::GoatState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    req: axum::extract::Request,
+    next: Next,
+) -> Response {
+    let ip = peer_ip(&addr);
+    let rl = gs.read().await.rate_limit_state.clone();
+    match rl.limiter.check_key(&ip) {
+        Ok(()) => next.run(req).await,
+        Err(_) => RateLimited.into_response(),
+    }
+}
+
+pub fn rate_limit_state() -> RateLimitState {
+    RateLimitState::new()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn rate_limit_allows_burst() {
+        let state = RateLimitState::new();
+        let ip: IpAddr = "127.0.0.1".parse().expect("loopback");
+        for _ in 0..BURST {
+            assert!(state.limiter.check_key(&ip).is_ok(), "burst should pass");
+        }
+    }
+
+    #[test]
+    fn rate_limit_blocks_excess_burst() {
+        let state = RateLimitState::new();
+        let ip: IpAddr = "127.0.0.1".parse().expect("loopback");
+        for _ in 0..=BURST {
+            let _ = state.limiter.check_key(&ip);
+        }
+        assert!(
+            state.limiter.check_key(&ip).is_err(),
+            "over-burst should be blocked"
+        );
+    }
+
+    #[test]
+    fn rate_limit_per_ip_isolation() {
+        let state = RateLimitState::new();
+        let ip_a: IpAddr = "10.0.0.1".parse().expect("a");
+        let ip_b: IpAddr = "10.0.0.2".parse().expect("b");
+        for _ in 0..=BURST {
+            let _ = state.limiter.check_key(&ip_a);
+        }
+        assert!(state.limiter.check_key(&ip_a).is_err(), "a exhausted");
+        assert!(state.limiter.check_key(&ip_b).is_ok(), "b unaffected");
+    }
+}

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -11,6 +11,7 @@ use crate::error::GoatNsError;
 
 // TODO: return the API docs use crate::web::api::docs::ApiDoc;
 use crate::web::middleware::csp;
+use crate::web::middleware::rate_limit::RateLimitState;
 use async_trait::async_trait;
 use axum::Router;
 use axum::extract::FromRef;
@@ -134,6 +135,7 @@ pub struct GoatChildState {
     pub oidc_config: Option<auth::CustomProviderMetadata>,
     pub oidc_verifier: std::collections::HashMap<String, (String, Nonce)>,
     pub csp_matchers: Vec<CspUrlMatcher>,
+    pub rate_limit_state: RateLimitState,
 }
 
 fn check_static_dir_exists(static_dir: &PathBuf, config: &ConfigFile) -> bool {
@@ -199,6 +201,7 @@ async fn build_router(
         oidc_config: None,
         oidc_verifier: HashMap::new(),
         csp_matchers,
+        rate_limit_state: crate::web::middleware::rate_limit::rate_limit_state(),
     }));
 
     let service_layer = ServiceBuilder::new()
@@ -209,11 +212,15 @@ async fn build_router(
         .route(&Urls::Home.to_string(), get(generic::index))
         .nest("/ui", ui::new())
         .nest("/api", api::new())
+        .nest("/auth", auth::new())
+        .layer(from_fn_with_state(
+            state.clone(),
+            crate::web::middleware::rate_limit::rate_limit_middleware,
+        ))
         .merge(
             utoipa_swagger_ui::SwaggerUi::new("/api/docs")
                 .url("/api/openapi.json", api::docs::ApiDoc::openapi()),
         )
-        .nest("/auth", auth::new())
         .nest("/dns-query", doh::new())
         .with_state(state)
         .layer(service_layer);
@@ -284,7 +291,7 @@ pub async fn build_with_listener(
         let handle = axum_server::Handle::new();
         let server = axum_server::from_tcp_rustls(listener, tls_config.clone())?
             .handle(handle.clone())
-            .serve(router.into_make_service());
+            .serve(router.into_make_service_with_connect_info::<SocketAddr>());
         tokio::pin!(server);
 
         loop {

--- a/src/web/ui/admin_ui.rs
+++ b/src/web/ui/admin_ui.rs
@@ -1,14 +1,11 @@
-use std::str::FromStr;
-
-use super::check_logged_in;
 use crate::db::entities;
+use crate::web::constants::SESSION_USER_KEY;
 use crate::web::middleware::admin::require_admin;
 use crate::web::utils::Urls;
 use crate::web::{GoatState, GoatStateTrait};
 use askama::Template;
 use askama_web::WebTemplate;
 use axum::extract::{Path, State};
-use axum::http::Uri;
 use axum::middleware::from_fn;
 use axum::response::Redirect;
 use axum::routing::get;
@@ -47,12 +44,14 @@ pub(crate) struct ZoneRecord {
 }
 
 #[instrument(level = "info", skip_all)]
-pub(crate) async fn dashboard(mut session: Session) -> Result<AdminUITemplate, Redirect> {
-    let url = Uri::from_str(&Urls::Home.to_string()).map_err(|err| {
-        error!("Failed to parse Urls::Home.to_string() as URL, this is a bug!: {err:?}");
-        Urls::Home.redirect()
-    })?;
-    let user = check_logged_in(&mut session, url).await?;
+pub(crate) async fn dashboard(session: Session) -> Result<AdminUITemplate, Redirect> {
+    let user: entities::users::Model = match session.get(SESSION_USER_KEY).await {
+        Ok(Some(user)) => user,
+        _ => {
+            debug!("Admin dashboard: no valid session user");
+            return Err(Redirect::to(&Urls::Login.to_string()));
+        }
+    };
 
     Ok(AdminUITemplate {
         user_is_admin: user.admin,
@@ -60,45 +59,56 @@ pub(crate) async fn dashboard(mut session: Session) -> Result<AdminUITemplate, R
 }
 
 pub(crate) async fn report_unowned_records(
-    mut session: Session,
+    session: Session,
     State(state): State<GoatState>,
 ) -> Result<AdminReportUnownedRecords, Redirect> {
-    let url = Uri::from_str(&Urls::Home.to_string()).map_err(|err| {
-        error!("Failed to parse Urls::Home.to_string() as URL, this is a bug!: {err:?}");
-        Urls::Home.redirect()
-    })?;
-    let user = check_logged_in(&mut session, url).await?;
+    let user: entities::users::Model = match session.get(SESSION_USER_KEY).await {
+        Ok(Some(user)) => user,
+        _ => {
+            debug!("Admin report_unowned_records: no valid session user");
+            return Err(Redirect::to(&Urls::Login.to_string()));
+        }
+    };
 
-    let txn = state.get_db_txn().await.map_err(|err| {
-        error!("Failed to get DB connection: {err:?}");
-        Urls::ZonesList.redirect()
-    })?;
+    let txn = match state.get_db_txn().await {
+        Ok(txn) => txn,
+        Err(err) => {
+            error!("Failed to get DB connection: {err:?}");
+            return Err(Redirect::to(&Urls::ZonesList.to_string()));
+        }
+    };
 
     // Get all zone IDs that have ownership records
-    let owned_zone_ids: Vec<Uuid> = entities::ownership::Entity::find()
+    let owned_zone_ids: Vec<Uuid> = match entities::ownership::Entity::find()
         .select_only()
         .column(entities::ownership::Column::Zoneid)
         .into_tuple()
         .all(&txn)
         .await
-        .map_err(|err| {
+    {
+        Ok(ids) => ids,
+        Err(err) => {
             error!("Failed to query ownership: {err:?}");
-            Urls::Admin.redirect()
-        })?;
+            return Err(Redirect::to(&Urls::Admin.to_string()));
+        }
+    };
 
     // Get zones that don't have ownership records
-    let unowned_zones = entities::zones::Entity::find()
+    let unowned_zones = match entities::zones::Entity::find()
         .filter(entities::zones::Column::Id.is_not_in(owned_zone_ids))
         .all(&txn)
         .await
-        .map_err(|err| {
+    {
+        Ok(zones) => zones,
+        Err(err) => {
             error!("Failed to get unowned zones: {err:?}");
-            Urls::Admin.redirect()
-        })?;
+            return Err(Redirect::to(&Urls::Admin.to_string()));
+        }
+    };
 
     Ok(AdminReportUnownedRecords {
         user_is_admin: user.admin,
-        records: vec![], // Records report not currently implemented
+        records: vec![],
         zones: unowned_zones,
     })
 }
@@ -119,76 +129,74 @@ pub(crate) struct AssignOwnershipForm {
 
 #[instrument(level = "info", skip(session, state))]
 pub(crate) async fn assign_zone_ownership(
-    mut session: Session,
+    session: Session,
     State(state): State<GoatState>,
     Path(id): Path<Uuid>,
     Form(form): Form<AssignOwnershipForm>,
 ) -> Result<AssignOwnershipTemplate, Redirect> {
-    let url = Uri::from_str(&Urls::Home.to_string()).map_err(|err| {
-        error!("Failed to parse Urls::Home.to_string() as URL, this is a bug!: {err:?}");
-        Urls::Home.redirect()
-    })?;
-    let current_user = check_logged_in(&mut session, url).await?;
+    let current_user: entities::users::Model = match session.get(SESSION_USER_KEY).await {
+        Ok(Some(user)) => user,
+        _ => {
+            debug!("Admin assign_zone_ownership: no valid session user");
+            return Err(Redirect::to(&Urls::Login.to_string()));
+        }
+    };
 
-    let txn = state.get_db_txn().await.map_err(|err| {
-        error!("Failed to get DB transaction: {err:?}");
-        Urls::Admin.redirect()
-    })?;
+    let txn = match state.get_db_txn().await {
+        Ok(txn) => txn,
+        Err(err) => {
+            error!("Failed to get DB transaction: {err:?}");
+            return Err(Redirect::to(&Urls::Admin.to_string()));
+        }
+    };
 
-    let zone = entities::zones::Entity::find_by_id(id)
-        .one(&txn)
-        .await
-        .map_err(|err| {
+    let zone = match entities::zones::Entity::find_by_id(id).one(&txn).await {
+        Ok(Some(zone)) => zone,
+        Ok(None) => {
+            error!("No zone found with ID: {id}");
+            return Err(Redirect::to(&Urls::Admin.to_string()));
+        }
+        Err(err) => {
             error!("Failed to get zone by ID: {err:?}");
-            Urls::Admin.redirect()
-        })?
-        .ok_or_else(|| {
-            error!("No zone found with ID: {}", id);
-            Urls::Admin.redirect()
-        })?;
+            return Err(Redirect::to(&Urls::Admin.to_string()));
+        }
+    };
 
     if let Some(username) = form.username.as_ref() {
         debug!("Got a username in the form!");
-        let target_user = entities::users::Entity::find()
+        let target_user = match entities::users::Entity::find()
             .filter(entities::users::Column::Username.eq(username.as_str()))
             .one(&txn)
             .await
-            .map_err(|err| {
+        {
+            Ok(Some(user)) => user,
+            Ok(None) => {
+                return Err(Redirect::to(&Urls::Admin.to_string()));
+            }
+            Err(err) => {
                 error!("Failed to get user by name: {err:?}");
-                Urls::Admin.redirect()
-            })?;
+                return Err(Redirect::to(&Urls::Admin.to_string()));
+            }
+        };
 
-        if let Some(target_user) = target_user {
-            // Create ownership record
-            let ownership = entities::ownership::ActiveModel {
-                id: sea_orm::ActiveValue::NotSet,
-                zoneid: Set(zone.id),
-                userid: Set(target_user.id),
-            };
+        // Create ownership record
+        let ownership = entities::ownership::ActiveModel {
+            id: sea_orm::ActiveValue::NotSet,
+            zoneid: Set(zone.id),
+            userid: Set(target_user.id),
+        };
 
-            ownership.insert(&txn).await.map_err(|err| {
-                error!("Failed to insert zone ownership: {err:?}");
-                Urls::Admin.redirect_with_query(
-                    [("message", format!("Failed to assign ownership: {err:?}"))]
-                        .into_iter()
-                        .collect(),
-                )
-            })?;
-
-            txn.commit().await.map_err(|err| {
-                error!("Failed to commit transaction: {err:?}");
-                Urls::Admin.redirect()
-            })?;
-
-            return Err(Urls::Admin.redirect_with_query(
-                [(
-                    "message",
-                    format!("Ownership assigned to {}", target_user.displayname),
-                )]
-                .into_iter()
-                .collect(),
-            ));
+        if let Err(err) = ownership.insert(&txn).await {
+            error!("Failed to insert zone ownership: {err:?}");
+            return Err(Redirect::to(&Urls::Admin.to_string()));
         }
+
+        if let Err(err) = txn.commit().await {
+            error!("Failed to commit transaction: {err:?}");
+            return Err(Redirect::to(&Urls::Admin.to_string()));
+        }
+
+        return Err(Redirect::to(&Urls::Admin.to_string()));
     }
 
     Ok(AssignOwnershipTemplate {

--- a/src/web/ui/admin_ui.rs
+++ b/src/web/ui/admin_ui.rs
@@ -2,12 +2,14 @@ use std::str::FromStr;
 
 use super::check_logged_in;
 use crate::db::entities;
+use crate::web::middleware::admin::require_admin;
 use crate::web::utils::Urls;
 use crate::web::{GoatState, GoatStateTrait};
 use askama::Template;
 use askama_web::WebTemplate;
 use axum::extract::{Path, State};
 use axum::http::Uri;
+use axum::middleware::from_fn;
 use axum::response::Redirect;
 use axum::routing::get;
 use axum::{Form, Router};
@@ -205,4 +207,5 @@ pub fn router() -> Router<GoatState> {
             "/zones/assign_ownership/{id}",
             get(assign_zone_ownership).post(assign_zone_ownership),
         )
+        .layer(from_fn(require_admin))
 }

--- a/src/web/ui/admin_ui.rs
+++ b/src/web/ui/admin_ui.rs
@@ -1,4 +1,4 @@
-use crate::db::entities;
+use crate::db::entities::{self, users};
 use crate::web::constants::SESSION_USER_KEY;
 use crate::web::middleware::admin::require_admin;
 use crate::web::utils::Urls;
@@ -45,11 +45,11 @@ pub(crate) struct ZoneRecord {
 
 #[instrument(level = "info", skip_all)]
 pub(crate) async fn dashboard(session: Session) -> Result<AdminUITemplate, Redirect> {
-    let user: entities::users::Model = match session.get(SESSION_USER_KEY).await {
+    let user: users::Model = match session.get(SESSION_USER_KEY).await {
         Ok(Some(user)) => user,
         _ => {
             debug!("Admin dashboard: no valid session user");
-            return Err(Redirect::to(&Urls::Login.to_string()));
+            return Err(Urls::Login.redirect());
         }
     };
 
@@ -62,11 +62,11 @@ pub(crate) async fn report_unowned_records(
     session: Session,
     State(state): State<GoatState>,
 ) -> Result<AdminReportUnownedRecords, Redirect> {
-    let user: entities::users::Model = match session.get(SESSION_USER_KEY).await {
+    let user: users::Model = match session.get(SESSION_USER_KEY).await {
         Ok(Some(user)) => user,
         _ => {
             debug!("Admin report_unowned_records: no valid session user");
-            return Err(Redirect::to(&Urls::Login.to_string()));
+            return Err(Urls::Login.redirect());
         }
     };
 
@@ -74,7 +74,7 @@ pub(crate) async fn report_unowned_records(
         Ok(txn) => txn,
         Err(err) => {
             error!("Failed to get DB connection: {err:?}");
-            return Err(Redirect::to(&Urls::ZonesList.to_string()));
+            return Err(Urls::ZonesList.redirect());
         }
     };
 
@@ -89,7 +89,7 @@ pub(crate) async fn report_unowned_records(
         Ok(ids) => ids,
         Err(err) => {
             error!("Failed to query ownership: {err:?}");
-            return Err(Redirect::to(&Urls::Admin.to_string()));
+            return Err(Urls::Admin.redirect());
         }
     };
 
@@ -102,7 +102,7 @@ pub(crate) async fn report_unowned_records(
         Ok(zones) => zones,
         Err(err) => {
             error!("Failed to get unowned zones: {err:?}");
-            return Err(Redirect::to(&Urls::Admin.to_string()));
+            return Err(Urls::Admin.redirect());
         }
     };
 
@@ -123,60 +123,82 @@ pub(crate) struct AssignOwnershipTemplate {
 
 #[derive(Deserialize, Debug)]
 pub(crate) struct AssignOwnershipForm {
-    // userid: Option<i64>,
     username: Option<String>,
 }
 
 #[instrument(level = "info", skip(session, state))]
-pub(crate) async fn assign_zone_ownership(
+pub(crate) async fn assign_zone_ownership_get(
+    session: Session,
+    State(state): State<GoatState>,
+    Path(id): Path<Uuid>,
+) -> Result<AssignOwnershipTemplate, Redirect> {
+    let Ok(Some(current_user)) = session.get::<users::Model>(SESSION_USER_KEY).await else {
+        debug!("Admin assign_zone_ownership: no valid session user");
+        return Err(Urls::Login.redirect());
+    };
+    let txn = state
+        .get_db_txn()
+        .await
+        .map_err(|_| Urls::Admin.redirect())?;
+
+    let Some(zone) = entities::zones::Entity::find_by_id(id)
+        .one(&txn)
+        .await
+        .map_err(|err| {
+            error!("Failed to get zone by ID: {err:?}");
+            Urls::Admin.redirect()
+        })?
+    else {
+        error!("No zone found with ID: {id}");
+        return Err(Urls::Admin.redirect());
+    };
+    Ok(AssignOwnershipTemplate {
+        user_is_admin: current_user.admin,
+        zone,
+        user: None,
+    })
+}
+
+#[instrument(level = "info", skip(session, state))]
+pub(crate) async fn assign_zone_ownership_post(
     session: Session,
     State(state): State<GoatState>,
     Path(id): Path<Uuid>,
     Form(form): Form<AssignOwnershipForm>,
 ) -> Result<AssignOwnershipTemplate, Redirect> {
-    let current_user: entities::users::Model = match session.get(SESSION_USER_KEY).await {
-        Ok(Some(user)) => user,
-        _ => {
-            debug!("Admin assign_zone_ownership: no valid session user");
-            return Err(Redirect::to(&Urls::Login.to_string()));
-        }
+    let Ok(Some(current_user)) = session.get::<users::Model>(SESSION_USER_KEY).await else {
+        debug!("Admin assign_zone_ownership: no valid session user");
+        return Err(Urls::Login.redirect());
     };
 
-    let txn = match state.get_db_txn().await {
-        Ok(txn) => txn,
-        Err(err) => {
-            error!("Failed to get DB transaction: {err:?}");
-            return Err(Redirect::to(&Urls::Admin.to_string()));
-        }
-    };
+    let txn = state
+        .get_db_txn()
+        .await
+        .map_err(|_| Urls::Admin.redirect())?;
 
-    let zone = match entities::zones::Entity::find_by_id(id).one(&txn).await {
-        Ok(Some(zone)) => zone,
-        Ok(None) => {
-            error!("No zone found with ID: {id}");
-            return Err(Redirect::to(&Urls::Admin.to_string()));
-        }
-        Err(err) => {
+    let Some(zone) = entities::zones::Entity::find_by_id(id)
+        .one(&txn)
+        .await
+        .map_err(|err| {
             error!("Failed to get zone by ID: {err:?}");
-            return Err(Redirect::to(&Urls::Admin.to_string()));
-        }
+            Urls::Admin.redirect()
+        })?
+    else {
+        error!("No zone found with ID: {id}");
+        return Err(Urls::Admin.redirect());
     };
 
     if let Some(username) = form.username.as_ref() {
         debug!("Got a username in the form!");
-        let target_user = match entities::users::Entity::find()
-            .filter(entities::users::Column::Username.eq(username.as_str()))
+        let Ok(Some(target_user)) = users::Entity::find()
+            .filter(users::Column::Username.eq(username.as_str()))
             .one(&txn)
             .await
-        {
-            Ok(Some(user)) => user,
-            Ok(None) => {
-                return Err(Redirect::to(&Urls::Admin.to_string()));
-            }
-            Err(err) => {
+            .inspect_err(|err| {
                 error!("Failed to get user by name: {err:?}");
-                return Err(Redirect::to(&Urls::Admin.to_string()));
-            }
+            })
+        else {
+            return Err(Urls::Admin.redirect());
         };
 
         // Create ownership record
@@ -188,15 +210,15 @@ pub(crate) async fn assign_zone_ownership(
 
         if let Err(err) = ownership.insert(&txn).await {
             error!("Failed to insert zone ownership: {err:?}");
-            return Err(Redirect::to(&Urls::Admin.to_string()));
+            return Err(Urls::Admin.redirect());
         }
 
         if let Err(err) = txn.commit().await {
             error!("Failed to commit transaction: {err:?}");
-            return Err(Redirect::to(&Urls::Admin.to_string()));
+            return Err(Urls::Admin.redirect());
         }
 
-        return Err(Redirect::to(&Urls::Admin.to_string()));
+        return Err(Urls::Admin.redirect());
     }
 
     Ok(AssignOwnershipTemplate {
@@ -213,7 +235,7 @@ pub fn router() -> Router<GoatState> {
         .route("/reports/unowned_records", get(report_unowned_records))
         .route(
             "/zones/assign_ownership/{id}",
-            get(assign_zone_ownership).post(assign_zone_ownership),
+            get(assign_zone_ownership_get).post(assign_zone_ownership_post),
         )
         .layer(from_fn(require_admin))
 }

--- a/src/web/ui/user_settings.rs
+++ b/src/web/ui/user_settings.rs
@@ -7,7 +7,7 @@ use askama::Template;
 use askama_web::WebTemplate;
 use axum::extract::{OriginalUri, Path, State};
 use axum::http::Uri;
-use axum::response::{Html, IntoResponse, Redirect};
+use axum::response::{Html, Redirect};
 use axum::routing::{get, post};
 use axum::{Form, Router};
 use chrono::{DateTime, TimeDelta, Utc};
@@ -30,10 +30,15 @@ pub(crate) struct Settings {
 }
 
 /// The user settings page at /ui/settings
-pub(crate) async fn settings(State(_state): State<GoatState>) -> Settings {
-    Settings {
-        user_is_admin: true,
-    }
+pub(crate) async fn settings(mut session: Session) -> Result<Settings, Redirect> {
+    let url = Uri::from_str(&Urls::Settings.to_string()).map_err(|err| {
+        error!("Failed to parse Urls::Settings as URL, this is a bug!: {err:?}");
+        Urls::Home.redirect()
+    })?;
+    let user = check_logged_in(&mut session, url).await?;
+    Ok(Settings {
+        user_is_admin: user.admin,
+    })
 }
 
 #[derive(Template, WebTemplate)]
@@ -323,7 +328,7 @@ pub async fn api_tokens_post(
     mut session: Session,
     State(state): State<GoatState>,
     Form(form): Form<ApiTokenForm>,
-) -> Result<impl IntoResponse, Redirect> {
+) -> Result<ApiTokenPage, Redirect> {
     eprintln!("Got form: {form:?}");
 
     let url = Uri::from_str(&Urls::SettingsApiTokens.to_string()).map_err(|err| {
@@ -365,7 +370,6 @@ pub async fn api_tokens_post(
                 token_value: None,
                 user_is_admin: user.admin,
             }
-            .into_response()
         }
         // The user has set a lifetime and we're generating a token
         ApiTokenCreatePageState::Generating => {

--- a/src/web/ui/zones.rs
+++ b/src/web/ui/zones.rs
@@ -108,6 +108,7 @@ pub(crate) async fn zones_new_post(
         retry: NotSet,
         expire: NotSet,
         minimum: NotSet,
+        signed: Set(false),
     };
 
     let (os_tx, os_rx) = tokio::sync::oneshot::channel();

--- a/src/web/ui/zones.rs
+++ b/src/web/ui/zones.rs
@@ -2,6 +2,7 @@
 
 use crate::datastore::Command;
 use crate::db::entities;
+use crate::utils::check_valid_tld;
 use crate::web::GoatState;
 use crate::web::ui::check_logged_in;
 use crate::web::utils::Urls;
@@ -42,6 +43,14 @@ pub(crate) async fn zones_new_post(
         return Err(Urls::Home.redirect_with_query(HashMap::from([(
             "error".to_string(),
             "Invalid DNS name".to_string(),
+        )])));
+    }
+
+    // Validate the TLD is in the allowed list
+    if !check_valid_tld(&form.name, &state.read().await.config.allowed_tlds) {
+        return Err(Urls::Home.redirect_with_query(HashMap::from([(
+            "error".to_string(),
+            "TLD not allowed".to_string(),
         )])));
     }
 

--- a/src/web/utils.rs
+++ b/src/web/utils.rs
@@ -2,13 +2,14 @@ use crate::db::entities;
 use argon2::password_hash::SaltString;
 use argon2::password_hash::rand_core::OsRng;
 use argon2::{Argon2, PasswordHasher, PasswordVerifier};
-use axum::http::StatusCode;
+use axum::http::{StatusCode, Uri};
 use axum::response::{Html, Redirect};
 use chrono::{DateTime, TimeDelta, Utc};
 use rand::distr::{Alphanumeric, SampleString};
 use sea_orm::ActiveValue::{NotSet, Set};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use std::str::FromStr;
 use tracing::{debug, trace};
 use uuid::Uuid;
 
@@ -65,6 +66,14 @@ impl Urls {
             .join("&");
         let url = format!("{}?{}", self, queryparts);
         Redirect::to(&url)
+    }
+}
+
+impl TryFrom<Urls> for Uri {
+    type Error = String;
+
+    fn try_from(value: Urls) -> Result<Self, Self::Error> {
+        Self::from_str(&value.to_string()).map_err(|e| format!("Failed to parse URL: {e:?}"))
     }
 }
 

--- a/src/zones.rs
+++ b/src/zones.rs
@@ -45,6 +45,9 @@ pub struct FileZone {
     /// MINIMUM - The unsigned 32 bit minimum TTL field that should be exported with any RR from this zone.
     #[serde(default)]
     pub minimum: u32,
+    /// Whether this zone is DNSSEC-signed (controls the ad bit in responses)
+    #[serde(default)]
+    pub signed: bool,
     /// The records associated with this zone
     pub records: Vec<FileZoneRecord>,
 }
@@ -94,6 +97,7 @@ impl FileZone {
             retry: Set(self.retry),
             expire: Set(self.expire),
             minimum: Set(self.minimum),
+            signed: Set(self.signed),
         };
 
         let zone_model = zone.insert(&txn).await?;
@@ -102,10 +106,15 @@ impl FileZone {
         for record in &self.records {
             let rrtype: crate::enums::RecordType = record.rrtype.as_str().into();
 
+            let name = if record.name == "@" {
+                String::new()
+            } else {
+                record.name.clone()
+            };
             let record_model = entities::records::ActiveModel {
                 id: NotSet,
                 zoneid: Set(zone_model.id),
-                name: Set(record.name.clone()),
+                name: Set(name),
                 ttl: Set(Some(record.ttl)),
                 rrtype: Set(rrtype as u16),
                 rclass: Set(record.class as u16),
@@ -170,6 +179,8 @@ pub struct ZoneRecord {
     pub name: Vec<u8>,
     /// the records associated with this name
     pub typerecords: Vec<InternalResourceRecord>,
+    /// whether this zone is DNSSEC-signed (controls the ad bit in responses)
+    pub signed: bool,
 }
 
 impl Display for ZoneRecord {

--- a/src/zones.rs
+++ b/src/zones.rs
@@ -9,10 +9,12 @@ use tracing::*;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::fs::File;
-use std::io::Read;
+use std::io::{BufReader, Read};
 use std::path::Path;
 use std::str::from_utf8;
 use utoipa::ToSchema;
+
+pub(crate) const MAX_ZONE_FILE_SIZE: u64 = 5 * 1024 * 1024;
 
 use sea_orm::{ActiveValue::Set, DatabaseConnection, TransactionTrait};
 use uuid::Uuid;
@@ -183,7 +185,7 @@ impl Display for ZoneRecord {
 
 /// Loads a zone file
 pub fn load_zone_from_file(filename: &Path) -> Result<ZoneFile, GoatNsError> {
-    let mut file = match File::open(filename) {
+    let file = match File::open(filename) {
         Ok(value) => value,
         Err(err) => {
             return Err(GoatNsError::FileError(format!(
@@ -191,18 +193,35 @@ pub fn load_zone_from_file(filename: &Path) -> Result<ZoneFile, GoatNsError> {
             )));
         }
     };
-    let mut buf: String = String::new();
-    file.read_to_string(&mut buf)
-        .inspect_err(|err| error!("Failed to read {}: {:?}", &filename.display(), err))?;
-    let jsonstruct: ZoneFile = match json5::from_str(&buf) {
-        Ok(value) => value,
+
+    let file_size = match file.metadata() {
+        Ok(meta) => meta.len(),
         Err(err) => {
-            let emsg = format!("Failed to read JSON file: {err:?}");
-            error!("{emsg}");
-            return Err(GoatNsError::FileError(emsg));
+            return Err(GoatNsError::FileError(format!(
+                "Failed to read file metadata: {err:?}"
+            )));
         }
     };
-    Ok(jsonstruct)
+
+    if file_size <= MAX_ZONE_FILE_SIZE {
+        let mut buf = String::new();
+        BufReader::new(file)
+            .read_to_string(&mut buf)
+            .inspect_err(|err| error!("Failed to read {}: {:?}", &filename.display(), err))?;
+        let jsonstruct: ZoneFile = match json5::from_str(&buf) {
+            Ok(value) => value,
+            Err(err) => {
+                let emsg = format!("Failed to read JSON file: {err:?}");
+                error!("{emsg}");
+                return Err(GoatNsError::FileError(emsg));
+            }
+        };
+        Ok(jsonstruct)
+    } else {
+        serde_json::from_reader(BufReader::new(file)).map_err(|err| {
+            GoatNsError::FileError(format!("Failed to parse zone file in streaming mode: {err:?}"))
+        })
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -215,7 +234,7 @@ pub struct ZoneFile {
 /// Loads a zone file
 #[instrument(level = "debug")]
 pub fn load_zones(filename: &str) -> Result<Vec<ZoneFile>, GoatNsError> {
-    let mut file = match File::open(filename) {
+    let file = match File::open(filename) {
         Ok(value) => value,
         Err(err) => {
             return Err(GoatNsError::FileError(format!(
@@ -224,9 +243,26 @@ pub fn load_zones(filename: &str) -> Result<Vec<ZoneFile>, GoatNsError> {
         }
     };
 
+    let file_size = match file.metadata() {
+        Ok(meta) => meta.len(),
+        Err(err) => {
+            return Err(GoatNsError::FileError(format!(
+                "Failed to read file metadata: {err:?}"
+            )));
+        }
+    };
+
+    if file_size <= MAX_ZONE_FILE_SIZE {
+        load_zones_small(file)
+    } else {
+        load_zones_streaming(file, file_size)
+    }
+}
+
+fn load_zones_small(mut file: File) -> Result<Vec<ZoneFile>, GoatNsError> {
     let mut buf: String = String::new();
     file.read_to_string(&mut buf)
-        .inspect_err(|err| error!("Failed to read {}: {:?}", filename, err))?;
+        .inspect_err(|err| error!("Failed to read file: {:?}", err))?;
     let jsonblob: Vec<serde_json::Value> =
         json5::from_str(&buf).map_err(|err| GoatNsError::FileError(err.to_string()))?;
     let mut zones: Vec<ZoneFile> = Vec::new();
@@ -238,5 +274,19 @@ pub fn load_zones(filename: &str) -> Result<Vec<ZoneFile>, GoatNsError> {
         );
     }
 
+    Ok(zones)
+}
+
+fn load_zones_streaming(file: File, file_size: u64) -> Result<Vec<ZoneFile>, GoatNsError> {
+    let reader = BufReader::new(file);
+    let zones: Vec<ZoneFile> = serde_json::from_reader(reader).map_err(|err| {
+        GoatNsError::FileError(format!("Failed to parse zone file in streaming mode: {err:?}"))
+    })?;
+
+    debug!(
+        zones = zones.len(),
+        size = file_size,
+        "Loaded zones via streaming parser"
+    );
     Ok(zones)
 }


### PR DESCRIPTION
This branch adds DNSSEC-aware response handling, fixes a zone-root name matching bug, and hardens auth/session handling.

**DNSSEC & EDNS0**
- Serve DNSSEC record types: DNSKEY, RRSIG, NSEC, NSEC3, NSEC3PARAM, DS, CDNSKEY, CDS (`src/enums.rs`, `src/resourcerecord.rs`)
- Parse EDNS0 OPT pseudo-RR from queries, propagate the DO bit, and include OPT in responses (`src/lib.rs:OptRecord`, `src/servers.rs`)
- Set the AD bit in responses for signed zones; include RRSIG records when the client sets DO (`src/datastore.rs`, `src/zones.rs:signed` field)
- Add `signed` column to zones via migration `m_20260626_dnssec.rs`

**Bug fix**
- Fix `'@'` record name not matching the zone root in queries — migration `m_20260627_fix_at_sign_name.rs` updates the `records_merged` view so `@`/empty names resolve to the zone name

**Security & middleware**
- Add `require_admin` middleware enforcing admin-only access (`src/web/middleware/admin.rs`)
- Add IP-based rate-limiting middleware (`src/web/middleware/rate_limit.rs`, 100/s burst 10)
- Harden auth: remove redundant login checks, fix TLD validation, redact token values from logs (`src/web/api/auth.rs`, `src/web/ui/admin_ui.rs`)
- Clear TLS hash buffer after use and log hash errors (`src/cert_reloader.rs`)

**Other**
- Accept `PathBuf` for config file path (`src/cli.rs`, `src/config.rs`)
- Cap zone-file reads at 5 MiB, fall back to streaming JSON parser above that to avoid memory DoS (`src/zones.rs`)
- Version bump, dependency updates, admin UI tweaks, and new DNSSEC integration tests (`src/tests/dnssec.rs`)

Docs: added `docs/src/dnssec.md` and `docs/src/security_audit_2026-06-26.md`, updated `docs/src/rrtypes.md`.